### PR TITLE
test/step1-4: テストの汎用化とvitest-fail-on-console導入

### DIFF
--- a/tests/setup/vitest.setup.ts
+++ b/tests/setup/vitest.setup.ts
@@ -1,27 +1,10 @@
 import '@testing-library/jest-dom'
+import failOnConsole from 'vitest-fail-on-console'
 
-// vitest-fail-on-consoleの設定をカスタマイズ
-import { beforeEach, afterEach } from 'vitest'
-
-let originalError: typeof console.error
-let originalWarn: typeof console.warn
-
-beforeEach(() => {
-  originalError = console.error
-  originalWarn = console.warn
-
-  console.error = (...args: unknown[]) => {
-    originalError(...args)
-    throw new Error(`Console error was called: ${args.join(' ')}`)
-  }
-
-  console.warn = (...args: unknown[]) => {
-    originalWarn(...args)
-    throw new Error(`Console warning was called: ${args.join(' ')}`)
-  }
-})
-
-afterEach(() => {
-  console.error = originalError
-  console.warn = originalWarn
+// vitest-fail-on-consoleの設定
+failOnConsole({
+  shouldFailOnError: true,
+  shouldFailOnWarn: true,
+  shouldFailOnLog: false,
+  shouldFailOnDebug: false,
 })

--- a/tests/unit/components/App.test.tsx
+++ b/tests/unit/components/App.test.tsx
@@ -18,4 +18,19 @@ describe('App - テスト環境の動作確認', () => {
     mockFn('test')
     expect(mockFn).toHaveBeenCalledWith('test')
   })
+
+  // vitest-fail-on-console動作確認テスト
+  // 注意: このテストは意図的にコンソールエラーを発生させて、vitest-fail-on-consoleが機能することを確認する
+  // 実際の運用時は削除またはコメントアウトする
+  test.skip('コンソールエラー検知テスト（vitest-fail-on-console動作確認）', () => {
+    // 以下のコメントを外すとテストが失敗するはず
+    // console.error('This is a test error for vitest-fail-on-console')
+    expect(true).toBe(true)
+  })
+
+  test.skip('コンソール警告検知テスト（vitest-fail-on-console動作確認）', () => {
+    // 以下のコメントを外すとテストが失敗するはず
+    // console.warn('This is a test warning for vitest-fail-on-console')
+    expect(true).toBe(true)
+  })
 })

--- a/tests/unit/components/App.test.tsx
+++ b/tests/unit/components/App.test.tsx
@@ -1,70 +1,21 @@
-import { describe, it, expect } from 'vitest'
-import { render, screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { describe, test, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
 import App from '../../../src/App'
 
-describe('App', () => {
-  it('基本レンダリングテスト: ViteとReactのロゴが表示される', () => {
-    render(<App />)
-
-    // ロゴ画像の確認
-    const viteLogoLink = screen.getByRole('link', { name: /vite logo/i })
-    const reactLogoLink = screen.getByRole('link', { name: /react logo/i })
-
-    expect(viteLogoLink).toBeInTheDocument()
-    expect(reactLogoLink).toBeInTheDocument()
+describe('App - テスト環境の動作確認', () => {
+  test('アプリケーションがクラッシュせずにレンダリングされる', () => {
+    const { container } = render(<App />)
+    expect(container).toBeTruthy()
   })
 
-  it('基本レンダリングテスト: Vite + Reactのタイトルが表示される', () => {
-    render(<App />)
-
-    const heading = screen.getByRole('heading', { name: /vite \+ react/i })
-    expect(heading).toBeInTheDocument()
+  test('DOM環境が正しく設定されている', () => {
+    expect(window).toBeDefined()
+    expect(document).toBeDefined()
   })
 
-  it('カウンターボタンの動作テスト', async () => {
-    const user = userEvent.setup()
-    render(<App />)
-
-    // カウンターボタンを取得
-    const button = screen.getByRole('button', { name: /count is 0/i })
-    expect(button).toBeInTheDocument()
-
-    // ボタンをクリック
-    await user.click(button)
-
-    // カウントが1になることを確認
-    expect(
-      screen.getByRole('button', { name: /count is 1/i })
-    ).toBeInTheDocument()
-  })
-
-  it('テキストコンテンツの確認', () => {
-    render(<App />)
-
-    // HMRに関するテキストの確認
-    expect(screen.getByText(/edit/i)).toBeInTheDocument()
-    expect(screen.getByText(/src\/app\.tsx/i)).toBeInTheDocument()
-    expect(screen.getByText(/and save to test hmr/i)).toBeInTheDocument()
-
-    // 詳細な説明テキストの確認
-    expect(
-      screen.getByText(/click on the vite and react logos to learn more/i)
-    ).toBeInTheDocument()
-  })
-
-  // vitest-fail-on-console動作確認テスト
-  // 注意: このテストは意図的にコンソールエラーを発生させて、vitest-fail-on-consoleが機能することを確認する
-  // 実際の運用時は削除またはコメントアウトする
-  it.skip('コンソールエラー検知テスト（vitest-fail-on-console動作確認）', () => {
-    // 以下のコメントを外すとテストが失敗するはず
-    // console.error('This is a test error for vitest-fail-on-console')
-    expect(true).toBe(true)
-  })
-
-  it.skip('コンソール警告検知テスト（vitest-fail-on-console動作確認）', () => {
-    // 以下のコメントを外すとテストが失敗するはず
-    // console.warn('This is a test warning for vitest-fail-on-console')
-    expect(true).toBe(true)
+  test('Vitestのモック機能が動作する', () => {
+    const mockFn = vi.fn()
+    mockFn('test')
+    expect(mockFn).toHaveBeenCalledWith('test')
   })
 })


### PR DESCRIPTION
- App.test.tsxをサイト固有のテストから汎用的なテスト環境確認用に変更
- vitest.setup.tsでカスタム実装からvitest-fail-on-consoleパッケージに変更
- テストがアプリケーションの変更に影響されにくい構造に改善
- vitest-fail-on-console動作確認テスト確認(コンソール警告検知テスト/コンソール警告検知テスト)
  - 確認後skip設定

Close #11