### PR TITLE
feat/step2-4: 編集モードでの削除機能実装

### DIFF
--- a/src/components/sheets/SheetList.tsx
+++ b/src/components/sheets/SheetList.tsx
@@ -11,6 +11,7 @@ interface SheetListProps {
   isEditMode?: boolean
   editingNewItem?: boolean
   onSheetClick?: (id: string) => void
+  onDeleteSheet?: (id: string) => void
   onNewItemConfirm?: (value: string) => void
   onNewItemCancel?: () => void
   onReorderSheets?: (activeId: string, overId: string) => void
@@ -22,6 +23,7 @@ export function SheetList({
   isEditMode = false,
   editingNewItem = false,
   onSheetClick,
+  onDeleteSheet,
   onNewItemConfirm,
   onNewItemCancel,
   onReorderSheets,
@@ -114,6 +116,7 @@ export function SheetList({
                   sheet={sheet}
                   isEditMode={isEditMode}
                   onSheetClick={handleSheetClick}
+                  onDeleteSheet={onDeleteSheet}
                 />
               ))}
 
@@ -145,6 +148,7 @@ export function SheetList({
               sheet={activeSheet}
               isEditMode={isEditMode}
               onSheetClick={() => {}}
+              onDeleteSheet={onDeleteSheet}
             />
           </div>
         )}

--- a/src/components/sheets/SheetListItem.tsx
+++ b/src/components/sheets/SheetListItem.tsx
@@ -1,19 +1,34 @@
 import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
+import { useState } from 'react'
+import { Trash2 } from 'lucide-react'
 import type { SheetMeta } from '@/types/sheet'
 import { DragHandle } from './DragHandle'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
 
 interface SheetListItemProps {
   sheet: SheetMeta
   isEditMode: boolean
   onSheetClick: (id: string) => void
+  onDeleteSheet?: (id: string) => void
 }
 
 export function SheetListItem({
   sheet,
   isEditMode,
   onSheetClick,
+  onDeleteSheet,
 }: SheetListItemProps) {
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false)
   const {
     attributes,
     listeners,
@@ -38,6 +53,19 @@ export function SheetListItem({
     if (!isEditMode) {
       onSheetClick(sheet.id)
     }
+  }
+
+  const handleDeleteClick = () => {
+    setShowDeleteDialog(true)
+  }
+
+  const handleDeleteConfirm = () => {
+    onDeleteSheet?.(sheet.id)
+    setShowDeleteDialog(false)
+  }
+
+  const handleDeleteCancel = () => {
+    setShowDeleteDialog(false)
   }
 
   return (
@@ -66,10 +94,43 @@ export function SheetListItem({
         <span className="text-base text-gray-900">{sheet.name}</span>
       </div>
       {isEditMode && (
-        <div {...attributes} {...listeners}>
-          <DragHandle isDragging={isDragging} />
+        <div className="flex items-center gap-2">
+          <button
+            data-testid="delete-button"
+            onClick={handleDeleteClick}
+            className="flex items-center justify-center min-h-11 min-w-11 p-2 text-red-500 hover:bg-red-50 rounded-lg transition-colors"
+            aria-label={`${sheet.name}を削除`}
+          >
+            <Trash2 className="w-5 h-5" />
+          </button>
+          <div {...attributes} {...listeners}>
+            <DragHandle isDragging={isDragging} />
+          </div>
         </div>
       )}
+
+      <AlertDialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>シートを削除</AlertDialogTitle>
+            <AlertDialogDescription>
+              "{sheet.name}
+              "を削除してもよろしいですか？この操作は取り消せません。
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel onClick={handleDeleteCancel}>
+              キャンセル
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDeleteConfirm}
+              className="bg-red-600 hover:bg-red-700 focus:ring-red-600"
+            >
+              削除
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   )
 }

--- a/src/pages/TopPage.tsx
+++ b/src/pages/TopPage.tsx
@@ -18,7 +18,7 @@ export function TopPage() {
   const inputRef = useRef<HTMLInputElement>(null)
 
   const { isEditMode, toggleEditMode } = useUIStore()
-  const { sheets, addSheet, reorderSheets } = useSheetsStore()
+  const { sheets, addSheet, removeSheet, reorderSheets } = useSheetsStore()
 
   const handleEditButtonClick = () => {
     toggleEditMode()
@@ -48,6 +48,10 @@ export function TopPage() {
   const handleSheetClick = (id: string) => {
     // TODO: 次のステップでルーティング実装
     console.log('シートをクリック:', id)
+  }
+
+  const handleDeleteSheet = (id: string) => {
+    removeSheet(id)
   }
 
   const handleEmptyNameAlertOk = useCallback(() => {
@@ -98,6 +102,7 @@ export function TopPage() {
           isEditMode={isEditMode}
           editingNewItem={editingNewItem}
           onSheetClick={handleSheetClick}
+          onDeleteSheet={handleDeleteSheet}
           onNewItemConfirm={handleNewItemConfirm}
           onNewItemCancel={handleNewItemCancel}
           onReorderSheets={reorderSheets}

--- a/src/store/sheetsStore.ts
+++ b/src/store/sheetsStore.ts
@@ -5,6 +5,7 @@ import type { SheetMeta } from '@/types/sheet'
 interface SheetsStore {
   sheets: SheetMeta[]
   addSheet: (name: string) => void
+  removeSheet: (id: string) => void
   reorderSheets: (activeId: string, overId: string) => void
   reset: () => void
 }
@@ -30,6 +31,11 @@ export const useSheetsStore = create<SheetsStore>((set, get) => ({
     }
     set(state => ({
       sheets: [...state.sheets, newSheet],
+    }))
+  },
+  removeSheet: (id: string) => {
+    set(state => ({
+      sheets: state.sheets.filter(sheet => sheet.id !== id),
     }))
   },
   reorderSheets: (activeId: string, overId: string) => {

--- a/tests/unit/store/sheetsStore.test.ts
+++ b/tests/unit/store/sheetsStore.test.ts
@@ -229,4 +229,141 @@ describe('SheetsStore', () => {
       expect(orders).toEqual([0, 1, 2])
     })
   })
+
+  describe('removeSheet', () => {
+    beforeEach(() => {
+      // テスト用のシートを3つ追加
+      const { addSheet } = useSheetsStore.getState()
+      addSheet('シート1')
+      addSheet('シート2')
+      addSheet('シート3')
+    })
+
+    it('removeSheet メソッドが存在する', () => {
+      const { removeSheet } = useSheetsStore.getState()
+      expect(typeof removeSheet).toBe('function')
+    })
+
+    it('指定IDのシートを削除できる', () => {
+      const { removeSheet } = useSheetsStore.getState()
+      const initialSheets = useSheetsStore.getState().sheets
+
+      // 2番目のシートのIDを取得
+      const secondSheetId = initialSheets[1].id
+
+      // シートを削除
+      removeSheet(secondSheetId)
+
+      const updatedSheets = useSheetsStore.getState().sheets
+
+      // 配列の長さが1つ減っている
+      expect(updatedSheets).toHaveLength(2)
+
+      // 削除されたシートが存在しない
+      expect(
+        updatedSheets.find(sheet => sheet.id === secondSheetId)
+      ).toBeUndefined()
+
+      // 残りのシートが正しく存在する
+      expect(updatedSheets[0].name).toBe('シート1')
+      expect(updatedSheets[1].name).toBe('シート3')
+    })
+
+    it('削除後のorder値が削除前の順序を維持する（歯抜けOK）', () => {
+      const { removeSheet } = useSheetsStore.getState()
+      const initialSheets = useSheetsStore.getState().sheets
+
+      // 2番目のシートを削除（order=1）
+      const secondSheetId = initialSheets[1].id
+      removeSheet(secondSheetId)
+
+      const updatedSheets = useSheetsStore.getState().sheets
+
+      // 残りのシートのorderが変更されない（歯抜けOK）
+      expect(updatedSheets[0].order).toBe(0) // シート1
+      expect(updatedSheets[1].order).toBe(2) // シート3
+    })
+
+    it('最初のシートを削除できる', () => {
+      const { removeSheet } = useSheetsStore.getState()
+      const initialSheets = useSheetsStore.getState().sheets
+
+      const firstSheetId = initialSheets[0].id
+      removeSheet(firstSheetId)
+
+      const updatedSheets = useSheetsStore.getState().sheets
+
+      expect(updatedSheets).toHaveLength(2)
+      expect(updatedSheets[0].name).toBe('シート2')
+      expect(updatedSheets[1].name).toBe('シート3')
+    })
+
+    it('最後のシートを削除できる', () => {
+      const { removeSheet } = useSheetsStore.getState()
+      const initialSheets = useSheetsStore.getState().sheets
+
+      const lastSheetId = initialSheets[2].id
+      removeSheet(lastSheetId)
+
+      const updatedSheets = useSheetsStore.getState().sheets
+
+      expect(updatedSheets).toHaveLength(2)
+      expect(updatedSheets[0].name).toBe('シート1')
+      expect(updatedSheets[1].name).toBe('シート2')
+    })
+
+    it('存在しないIDで削除を試行してもエラーにならない', () => {
+      const { removeSheet } = useSheetsStore.getState()
+
+      // 存在しないIDで実行してもエラーにならない
+      expect(() => {
+        removeSheet('non-existent-id')
+      }).not.toThrow()
+
+      // 元の配列が変更されない
+      const unchangedSheets = useSheetsStore.getState().sheets
+      expect(unchangedSheets).toHaveLength(3)
+      expect(unchangedSheets[0].name).toBe('シート1')
+      expect(unchangedSheets[1].name).toBe('シート2')
+      expect(unchangedSheets[2].name).toBe('シート3')
+    })
+
+    it('すべてのシートを削除して空にできる', () => {
+      const { removeSheet } = useSheetsStore.getState()
+      const initialSheets = useSheetsStore.getState().sheets
+
+      // すべてのシートを削除
+      initialSheets.forEach(sheet => {
+        removeSheet(sheet.id)
+      })
+
+      const emptySheets = useSheetsStore.getState().sheets
+      expect(emptySheets).toHaveLength(0)
+    })
+
+    it('削除処理が配列の整合性を保つ', () => {
+      const { removeSheet } = useSheetsStore.getState()
+      const initialSheets = useSheetsStore.getState().sheets
+
+      const secondSheetId = initialSheets[1].id
+      removeSheet(secondSheetId)
+
+      const updatedSheets = useSheetsStore.getState().sheets
+
+      // すべてのシートが有効なプロパティを持つ
+      updatedSheets.forEach(sheet => {
+        expect(typeof sheet.id).toBe('string')
+        expect(sheet.id).toBeTruthy()
+        expect(typeof sheet.name).toBe('string')
+        expect(sheet.name).toBeTruthy()
+        expect(typeof sheet.order).toBe('number')
+        expect(sheet.createdAt).toMatch(
+          /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/
+        )
+        expect(sheet.updatedAt).toMatch(
+          /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/
+        )
+      })
+    })
+  })
 })


### PR DESCRIPTION
### 目的 / 関連ステップ
step2-4: 編集モードでの削除機能実装

### 実装内容
- ZustandストアにremoveSheet アクション追加
- SheetListItemコンポーネントに削除ボタンとAlertDialog実装
- 編集モード時のみTrash2アイコン付き削除ボタン表示
- 削除確認ダイアログでキャンセル/削除選択可能
- モバイルファーストでタッチターゲット44px以上確保
- 削除後のorder値維持（歯抜けOK仕様）
- 包括的なユニットテスト・E2Eテスト追加

### 動作確認内容
- ✅ ユニットテスト: 56 tests passing
- ✅ E2Eテスト: 32 tests passing
- ✅ 全品質チェック通過 (TypeScript, ESLint, Prettier, Tests)
- ✅ devサーバーでエラーなしで動作確認

### 備考
Close #29

🤖 Generated with [Claude Code](https://claude.ai/code)