### PR TITLE
Step2-6-1: ルートモデル導入 - パート1：schemaVersion, savedAt, entitiesの実装

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,12 +58,13 @@ pocket-calcsheet_cca/
 │   │   └── TopPage.tsx               # トップページ（シート一覧）
 │   ├── store/                        # Zustandストア
 │   │   ├── index.ts                  # Zustandストア統合エクスポート
-│   │   ├── sheetsStore.ts            # シート一覧・永続化ストア(updateSheet実装済み)
+│   │   ├── sheetsStore.ts            # シート一覧・永続化ストア(ルートモデル対応済み)
 │   │   └── uiStore.ts                # UI一時状態ストア(非永続化)
 │   ├── lib/
 │   │   └── utils.ts                  # cnユーティリティ関数
 │   ├── types/
-│   │   └── sheet.ts                  # シートモデル型定義
+│   │   ├── sheet.ts                  # シートモデル型定義
+│   │   └── storage.ts                # ストレージ関連型定義（ルートモデル）
 │   ├── App.tsx                       # ルートコンポーネント(Router設定)
 │   ├── main.tsx                      # アプリケーションエントリーポイント
 │   ├── index.css                     # グローバルCSS、Tailwind CSSのインポート + SafeArea対応

--- a/src/types/storage.ts
+++ b/src/types/storage.ts
@@ -1,0 +1,15 @@
+import type { SheetMeta } from './sheet'
+
+// ルートモデルの型定義
+export interface RootModel {
+  schemaVersion: number
+  savedAt: string // ISO 8601
+  sheets: SheetMeta[]
+  entities: Record<string, Sheet> // 将来実装用、現在は空
+}
+
+// Sheet型は将来実装（現在はanyまたは最小限の型）
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface Sheet extends SheetMeta {
+  // 将来、概要データ、変数スロット、数式データを追加
+}


### PR DESCRIPTION
### 目的 / 関連ステップ
Step2-6-1の実装：ルートモデル構造の導入

### 実装内容
- ルートモデル構造の実装（schemaVersion, savedAt, sheets, entities）
- 既存シート操作機能の完全互換性維持
- 将来のentities拡張への基盤構築
- TDDアプローチによる32件のテスト追加

### 動作確認内容
- ✅ 全ユニットテスト86件パス
- ✅ TypeScript型チェックパス
- ✅ ESLint/Prettierチェックパス
- ✅ ビルド正常完了
- ✅ 開発サーバー正常起動

### 備考
Close #39

Generated with [Claude Code](https://claude.ai/code)