### PR TITLE
feat/step2-6-3: MigrationManager基盤実装

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,8 @@ pocket-calcsheet_cca/
 │   │   └── uiStore.ts                # UI一時状態ストア(非永続化)
 │   ├── utils/                        # ユーティリティ関数
 │   │   └── storage/                  # ストレージ関連ユーティリティ
-│   │       └── storageManager.ts     # localStorage抽象化レイヤー
+│   │       ├── storageManager.ts     # localStorage抽象化レイヤー
+│   │       └── migrationManager.ts   # スキーママイグレーション
 │   ├── lib/
 │   │   └── utils.ts                  # cnユーティリティ関数
 │   ├── types/
@@ -83,7 +84,7 @@ pocket-calcsheet_cca/
 │   │   │   └── useScrollToInput.test.ts # スクロール制御フックテスト
 │   │   └── store/
 │   │       ├── sheetsStore.test.ts   # シートストアテスト
-│   │       └── storageManager.test.ts # StorageManagerテスト
+│   │       └── storageManager.test.ts # StorageManager + MigrationManagerテスト
 │   └── e2e/
 │       ├── app.spec.ts               # 基本動作E2Eテスト
 │       └── pwa.spec.ts               # PWA機能テスト

--- a/src/utils/storage/migrationManager.ts
+++ b/src/utils/storage/migrationManager.ts
@@ -1,0 +1,63 @@
+import type { RootModel } from '@/types/storage'
+
+type MigrationFunction = (data: unknown) => RootModel
+
+export class MigrationManager {
+  private static migrations: Record<number, MigrationFunction> = {
+    0: data => MigrationManager.migrateV0ToV1(data),
+  }
+
+  static migrate(
+    data: unknown,
+    fromVersion: number,
+    toVersion: number
+  ): RootModel {
+    if (data === null || data === undefined) {
+      throw new Error('Invalid data provided for migration')
+    }
+
+    if (fromVersion > toVersion) {
+      throw new Error('Cannot migrate backwards')
+    }
+
+    let currentData = data
+    let currentVersion = fromVersion
+
+    while (currentVersion < toVersion) {
+      const migration = this.migrations[currentVersion]
+      if (migration) {
+        currentData = migration(currentData)
+      } else {
+        // マイグレーション関数が存在しない場合、schemaVersionのみ更新
+        const dataObj = currentData as Partial<RootModel>
+        currentData = {
+          ...dataObj,
+          schemaVersion: currentVersion + 1,
+        }
+      }
+      currentVersion++
+    }
+
+    return currentData as RootModel
+  }
+
+  static needsMigration(data: unknown): boolean {
+    if (data === null || data === undefined) {
+      return true
+    }
+
+    const rootModel = data as Partial<RootModel>
+    return !rootModel.schemaVersion || rootModel.schemaVersion < 1
+  }
+
+  static migrateV0ToV1(data: unknown): RootModel {
+    const dataObj = data as Partial<RootModel>
+
+    return {
+      schemaVersion: 1,
+      savedAt: dataObj.savedAt || new Date().toISOString(),
+      sheets: dataObj.sheets || [],
+      entities: dataObj.entities || {},
+    }
+  }
+}


### PR DESCRIPTION
### 目的 / 関連ステップ
Step2-6-3: 要素名, id, 順番の保存/読み出し(localStorage) - MigrationManager基盤実装

### 実装内容
- MigrationManagerクラスの実装（スキーマバージョン管理）
- needsMigration, migrate, migrateV0ToV1メソッド追加
- null/undefined/後方マイグレーション等の包括的エラーハンドリング
- 29個の単体テストでTDDアプローチによる品質保証
- CLAUDE.mdのディレクトリ構造を更新

### 動作確認内容
- 全ユニットテスト：✅ (120テスト)
- 全E2Eテスト：✅ (34テスト)
- 品質チェック：✅ (lint, format, build)

### 備考
Close #49

🤖 Generated with [Claude Code](https://claude.ai/code)