### PR TITLE
feat/step4-1: Variablesタブ画面構成の実装

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,8 @@ pocket-calcsheet_cca/
 │   │   │   ├── SheetList.tsx         # トップページのシート一覧表示(DndContext)
 │   │   │   ├── SheetListItem.tsx     # シート一覧の個別アイテム(SortableItem)
 │   │   │   └── DragHandle.tsx        # ドラッグ&ドロップ用ハンドル
+│   │   ├── calculator/               # 計算機能コンポーネント
+│   │   │   └── VariableSlot.tsx      # 変数スロット(名前+式+値)
 │   │   └── ui/                       # shadcn/uiコンポーネント
 │   │       ├── button.tsx            # Buttonコンポーネント
 │   │       ├── input.tsx             # 基本入力フィールド
@@ -74,6 +76,8 @@ pocket-calcsheet_cca/
 │   ├── utils/                        # ユーティリティ関数
 │   │   ├── constants/                # 定数定義
 │   │   │   └── routes.ts             # ルート定義・タブバリデーション
+│   │   ├── validation/               # バリデーション関連ユーティリティ
+│   │   │   └── variableValidation.ts # 変数名バリデーション
 │   │   └── storage/                  # ストレージ関連ユーティリティ
 │   │       ├── storageManager.ts     # localStorage抽象化レイヤー
 │   │       └── migrationManager.ts   # スキーママイグレーション
@@ -93,9 +97,12 @@ pocket-calcsheet_cca/
 │   │   ├── components/
 │   │   │   ├── App.test.tsx          # ベーシックテスト + Service Worker登録テスト + TopPageテスト + 画面切り替えテスト
 │   │   │   ├── SheetList.test.tsx    # シート一覧コンポーネントテスト
-│   │   │   └── TabNavigation.test.tsx # タブナビゲーション関連テスト
+│   │   │   ├── TabNavigation.test.tsx # タブナビゲーション関連テスト
+│   │   │   └── VariableSlot.test.tsx # 変数スロットテスト
 │   │   ├── hooks/
 │   │   │   └── useScrollToInput.test.ts # スクロール制御フックテスト
+│   │   ├── utils/
+│   │   │   └── validation.test.ts    # バリデーションテスト
 │   │   └── store/
 │   │       ├── sheetsStore.test.ts   # シートストアテスト
 │   │       └── storageManager.test.ts # StorageManager + MigrationManagerテスト

--- a/src/components/calculator/VariableSlot.tsx
+++ b/src/components/calculator/VariableSlot.tsx
@@ -1,0 +1,72 @@
+import { Input } from '@/components/ui/input'
+import type { VariableSlot as VariableSlotType } from '@/types/sheet'
+import {
+  isValidVariableName,
+  isDuplicateVariableName,
+} from '@/utils/validation/variableValidation'
+
+interface Props {
+  slot: VariableSlotType
+  slots: VariableSlotType[]
+  onChange: (updates: Partial<VariableSlotType>) => void
+  onValidationError: (message: string) => void
+}
+
+export function VariableSlot({
+  slot,
+  slots,
+  onChange,
+  onValidationError,
+}: Props) {
+  const handleNameChange = (value: string) => {
+    onChange({ varName: value })
+  }
+
+  const handleValueChange = (value: string) => {
+    onChange({ expression: value })
+  }
+
+  const handleNameBlur = () => {
+    const { varName } = slot
+
+    // バリデーションチェック
+    if (varName && !isValidVariableName(varName)) {
+      onValidationError(
+        '変数名が無効です。英字で始まり、英数字とアンダースコアのみ使用できます。'
+      )
+      return
+    }
+
+    if (isDuplicateVariableName(varName, slot.slot, slots)) {
+      onValidationError(
+        '重複した変数名です。他の変数と同じ名前は使用できません。'
+      )
+      return
+    }
+  }
+
+  return (
+    <div className="mb-4">
+      <div className="text-sm font-medium text-gray-700 mb-2">
+        Variable{slot.slot}
+      </div>
+      <div className="space-y-2">
+        <Input
+          data-testid={`variable-name-${slot.slot}`}
+          placeholder="変数名"
+          value={slot.varName}
+          onChange={e => handleNameChange(e.target.value)}
+          onBlur={handleNameBlur}
+          className="w-full"
+        />
+        <Input
+          data-testid={`variable-value-${slot.slot}`}
+          placeholder="値"
+          value={slot.expression}
+          onChange={e => handleValueChange(e.target.value)}
+          className="w-full"
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/components/calculator/VariableSlot.tsx
+++ b/src/components/calculator/VariableSlot.tsx
@@ -47,24 +47,32 @@ export function VariableSlot({
 
   return (
     <div className="mb-4">
-      <div className="text-sm font-medium text-gray-700 mb-2">
-        Variable{slot.slot}
+      <div className="flex items-center justify-between mb-2">
+        <div className="text-sm font-medium text-gray-700">
+          Variable{slot.slot}
+        </div>
+        <div className="text-sm text-gray-600 h-5">
+          {/* 計算値表示用スペース（後のステップで実装） */}
+        </div>
       </div>
-      <div className="space-y-2">
+      <div className="flex gap-2">
         <Input
           data-testid={`variable-name-${slot.slot}`}
           placeholder="変数名"
           value={slot.varName}
           onChange={e => handleNameChange(e.target.value)}
           onBlur={handleNameBlur}
-          className="w-full"
+          className="flex-1"
+          aria-label={`Variable${slot.slot} の名前`}
+          aria-invalid={!!slot.error}
         />
         <Input
           data-testid={`variable-value-${slot.slot}`}
           placeholder="値"
           value={slot.expression}
           onChange={e => handleValueChange(e.target.value)}
-          className="w-full"
+          className="flex-1"
+          aria-label={`Variable${slot.slot} の値`}
         />
       </div>
     </div>

--- a/src/components/layout/TabBar.tsx
+++ b/src/components/layout/TabBar.tsx
@@ -40,6 +40,7 @@ export function TabBar({ onTabChange }: TabBarProps) {
           <button
             key={tab.id}
             onClick={() => onTabChange(tab.id)}
+            data-testid={`tab-${tab.id}`}
             data-selected={currentTab === tab.id}
             aria-selected={currentTab === tab.id}
             role="tab"

--- a/src/pages/VariablesTab.tsx
+++ b/src/pages/VariablesTab.tsx
@@ -1,10 +1,92 @@
+import { useState, useEffect } from 'react'
+import { useParams } from 'react-router-dom'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+import { VariableSlot } from '@/components/calculator/VariableSlot'
+import { useSheetsStore } from '@/store'
+import type { VariableSlot as VariableSlotType } from '@/types/sheet'
+
 export function VariablesTab() {
+  const { id } = useParams<{ id: string }>()
+  const { entities, updateVariableSlot, initializeSheet } = useSheetsStore()
+  const [validationError, setValidationError] = useState<string>('')
+
+  const sheet = entities[id || '']
+
+  useEffect(() => {
+    if (id && sheet && !sheet.variableSlots) {
+      initializeSheet(id)
+    }
+  }, [id, sheet, initializeSheet])
+
+  const handleSlotChange = (
+    slotNumber: number,
+    updates: Partial<VariableSlotType>
+  ) => {
+    if (id) {
+      updateVariableSlot(id, slotNumber, updates)
+    }
+  }
+
+  const handleValidationError = (message: string) => {
+    setValidationError(message)
+  }
+
+  if (!sheet) {
+    return (
+      <div className="p-4">
+        <div className="text-gray-600">シートが見つかりません。</div>
+      </div>
+    )
+  }
+
+  if (!sheet.variableSlots) {
+    return (
+      <div className="p-4">
+        <div className="text-gray-600">読み込み中...</div>
+      </div>
+    )
+  }
+
   return (
-    <div className="p-4">
-      <h2 className="text-xl font-bold text-gray-900 mb-4">Variables</h2>
-      <p className="text-gray-600">
-        変数タブのプレースホルダーです。実装は後のステップで行います。
-      </p>
+    <div className="p-4 pb-20 h-full overflow-y-auto">
+      <h2 className="text-xl font-bold text-gray-900 mb-6">Variables</h2>
+      <div className="space-y-1">
+        {sheet.variableSlots.map(slot => (
+          <VariableSlot
+            key={slot.slot}
+            slot={slot}
+            slots={sheet.variableSlots}
+            onChange={updates => handleSlotChange(slot.slot, updates)}
+            onValidationError={handleValidationError}
+          />
+        ))}
+      </div>
+
+      {/* バリデーションエラーダイアログ */}
+      <AlertDialog
+        open={!!validationError}
+        onOpenChange={() => setValidationError('')}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>入力エラー</AlertDialogTitle>
+            <AlertDialogDescription>{validationError}</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogAction onClick={() => setValidationError('')}>
+              OK
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   )
 }

--- a/src/pages/VariablesTab.tsx
+++ b/src/pages/VariablesTab.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import { useParams } from 'react-router-dom'
 import {
   AlertDialog,
@@ -24,7 +24,8 @@ export function VariablesTab() {
     if (id && sheet && !sheet.variableSlots) {
       initializeSheet(id)
     }
-  }, [id, sheet, initializeSheet])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id, sheet?.variableSlots])
 
   const handleSlotChange = (
     slotNumber: number,
@@ -38,6 +39,10 @@ export function VariablesTab() {
   const handleValidationError = (message: string) => {
     setValidationError(message)
   }
+
+  const closeDialog = useCallback(() => {
+    setValidationError('')
+  }, [])
 
   if (!sheet) {
     return (
@@ -57,7 +62,6 @@ export function VariablesTab() {
 
   return (
     <div className="p-4 pb-20 h-full overflow-y-auto">
-      <h2 className="text-xl font-bold text-gray-900 mb-6">Variables</h2>
       <div className="space-y-1">
         {sheet.variableSlots.map(slot => (
           <VariableSlot
@@ -71,19 +75,14 @@ export function VariablesTab() {
       </div>
 
       {/* バリデーションエラーダイアログ */}
-      <AlertDialog
-        open={!!validationError}
-        onOpenChange={() => setValidationError('')}
-      >
+      <AlertDialog open={!!validationError} onOpenChange={closeDialog}>
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>入力エラー</AlertDialogTitle>
             <AlertDialogDescription>{validationError}</AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogAction onClick={() => setValidationError('')}>
-              OK
-            </AlertDialogAction>
+            <AlertDialogAction onClick={closeDialog}>OK</AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>

--- a/src/types/sheet.ts
+++ b/src/types/sheet.ts
@@ -14,3 +14,12 @@ export const validateSheetName = (name: string): ValidatedSheetName | null => {
 }
 
 export type TabType = 'overview' | 'variables' | 'formula'
+
+// 変数スロットの型定義
+export interface VariableSlot {
+  slot: number // 1〜8
+  varName: string // 変数名（空欄可）
+  expression: string // 入力式（数値または式）
+  value: number | null // 計算結果（本ステップでは未使用）
+  error: string | null // エラー内容（本ステップでは未使用）
+}

--- a/src/types/storage.ts
+++ b/src/types/storage.ts
@@ -1,15 +1,14 @@
-import type { SheetMeta } from './sheet'
+import type { SheetMeta, VariableSlot } from './sheet'
 
 // ルートモデルの型定義
 export interface RootModel {
   schemaVersion: number
   savedAt: string // ISO 8601
   sheets: SheetMeta[]
-  entities: Record<string, Sheet> // 将来実装用、現在は空
+  entities: Record<string, Sheet>
 }
 
-// Sheet型は将来実装（現在はanyまたは最小限の型）
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+// Sheet型の拡張
 export interface Sheet extends SheetMeta {
-  // 将来、概要データ、変数スロット、数式データを追加
+  variableSlots: VariableSlot[] // 8要素の配列
 }

--- a/src/utils/validation/variableValidation.ts
+++ b/src/utils/validation/variableValidation.ts
@@ -1,0 +1,18 @@
+import type { VariableSlot } from '@/types/sheet'
+
+// 変数名の正規表現
+const VARIABLE_NAME_PATTERN = /^[A-Za-z][A-Za-z0-9_]*$/
+
+export const isValidVariableName = (name: string): boolean => {
+  if (!name) return true // 空欄は許可
+  return VARIABLE_NAME_PATTERN.test(name)
+}
+
+export const isDuplicateVariableName = (
+  name: string,
+  currentSlot: number,
+  slots: VariableSlot[]
+): boolean => {
+  if (!name) return false // 空欄は重複チェック不要
+  return slots.some(slot => slot.slot !== currentSlot && slot.varName === name)
+}

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -231,91 +231,81 @@ test.describe('アプリケーション基本動作確認', () => {
     await expect(page.locator('text=新しいシート')).toBeVisible()
   })
 
-  test('Variables タブで8つの変数スロットが表示される @step4-1', async ({
-    page,
-  }) => {
-    await page.goto('/')
+  test.describe('Variables タブテスト @step4-1', () => {
+    const VARIABLE_SLOT_COUNT = 8
 
-    // テスト用のシートを追加
-    await page.locator('button:has-text("編集")').click()
-    await page.locator('button:has-text("+")').click()
-    const input = page.locator('[data-testid="new-sheet-input"]')
-    await input.fill('変数テストシート')
-    await input.press('Enter')
-    await page.locator('button:has-text("完了")').click()
+    test.beforeEach(async ({ page }) => {
+      await page.goto('/')
 
-    // シートをクリックして詳細画面に遷移
-    await page.locator('text=変数テストシート').click()
+      // 共通のセットアップ
+      await page.locator('button:has-text("編集")').click()
+      await page.locator('button:has-text("+")').click()
+      const input = page.locator('[data-testid="new-sheet-input"]')
+      await input.fill('テストシート')
+      await input.press('Enter')
+      await page.locator('button:has-text("完了")').click()
+      await page.locator('text=テストシート').click()
+      await page.locator('[data-testid="tab-variables"]').click()
+    })
 
-    // Variablesタブが表示されることを確認
-    await expect(page.locator('[data-testid="tab-variables"]')).toBeVisible()
+    test('8つの変数スロットが表示される', async ({ page }) => {
+      // Variable1〜8のラベルが表示されることを確認
+      for (let i = 1; i <= VARIABLE_SLOT_COUNT; i++) {
+        await expect(page.locator(`text=Variable${i}`)).toBeVisible()
+      }
 
-    // Variablesタブをクリック
-    await page.locator('[data-testid="tab-variables"]').click()
+      // 各スロットに変数名と値の入力フィールドが存在することを確認
+      for (let i = 1; i <= VARIABLE_SLOT_COUNT; i++) {
+        await expect(
+          page.locator(`[data-testid="variable-name-${i}"]`)
+        ).toBeVisible()
+        await expect(
+          page.locator(`[data-testid="variable-value-${i}"]`)
+        ).toBeVisible()
+      }
+    })
 
-    // Variable1〜8のラベルが表示されることを確認
-    for (let i = 1; i <= 8; i++) {
-      await expect(page.locator(`text=Variable${i}`)).toBeVisible()
-    }
+    test('変数名バリデーションが動作する', async ({ page }) => {
+      // 1. 日本語の変数名を入力（不正）
+      const nameInput1 = page.locator(`[data-testid="variable-name-1"]`)
+      await nameInput1.fill('変数名')
+      await nameInput1.blur()
 
-    // 各スロットに変数名と値の入力フィールドが存在することを確認
-    for (let i = 1; i <= 8; i++) {
-      await expect(
-        page.locator(`[data-testid="variable-name-${i}"]`)
-      ).toBeVisible()
-      await expect(
-        page.locator(`[data-testid="variable-value-${i}"]`)
-      ).toBeVisible()
-    }
-  })
+      // AlertDialogが表示されるまで少し待つ
+      await page.waitForTimeout(100)
 
-  test('変数名バリデーションが動作する @step4-1', async ({ page }) => {
-    await page.goto('/')
+      // AlertDialogが表示されることを確認
+      await expect(page.locator('[role="alertdialog"]')).toBeVisible()
+      await expect(page.getByText('変数名が無効です')).toBeVisible()
+      await page.locator('button:has-text("OK")').click()
 
-    // テスト用のシートを追加
-    await page.locator('button:has-text("編集")').click()
-    await page.locator('button:has-text("+")').click()
-    const input = page.locator('[data-testid="new-sheet-input"]')
-    await input.fill('バリデーションテストシート')
-    await input.press('Enter')
-    await page.locator('button:has-text("完了")').click()
+      // 2. 数字で始まる変数名を入力（不正）
+      await nameInput1.fill('1variable')
+      await nameInput1.blur()
 
-    // シートをクリックして詳細画面に遷移
-    await page.locator('text=バリデーションテストシート').click()
+      // AlertDialogが表示されるまで少し待つ
+      await page.waitForTimeout(100)
 
-    // Variablesタブをクリック
-    await page.locator('[data-testid="tab-variables"]').click()
+      // AlertDialogが表示されることを確認
+      await expect(page.locator('[role="alertdialog"]')).toBeVisible()
+      await page.locator('button:has-text("OK")').click()
 
-    // 1. 日本語の変数名を入力（不正）
-    const nameInput1 = page.locator(`[data-testid="variable-name-1"]`)
-    await nameInput1.fill('変数名')
-    await nameInput1.blur()
+      // 3. 有効な変数名を入力
+      await nameInput1.fill('validVar')
+      await nameInput1.blur()
 
-    // AlertDialogが表示されることを確認
-    await expect(page.locator('[role="alertdialog"]')).toBeVisible()
-    await expect(page.getByText('変数名が無効です')).toBeVisible()
-    await page.locator('button:has-text("OK")').click()
+      // 4. 同じ変数名を別のスロットに入力（重複）
+      const nameInput2 = page.locator(`[data-testid="variable-name-2"]`)
+      await nameInput2.fill('validVar')
+      await nameInput2.blur()
 
-    // 2. 数字で始まる変数名を入力（不正）
-    await nameInput1.fill('1variable')
-    await nameInput1.blur()
+      // AlertDialogが表示されるまで少し待つ
+      await page.waitForTimeout(100)
 
-    // AlertDialogが表示されることを確認
-    await expect(page.locator('[role="alertdialog"]')).toBeVisible()
-    await page.locator('button:has-text("OK")').click()
-
-    // 3. 有効な変数名を入力
-    await nameInput1.fill('validVar')
-    await nameInput1.blur()
-
-    // 4. 同じ変数名を別のスロットに入力（重複）
-    const nameInput2 = page.locator(`[data-testid="variable-name-2"]`)
-    await nameInput2.fill('validVar')
-    await nameInput2.blur()
-
-    // 重複エラーのAlertDialogが表示されることを確認
-    await expect(page.locator('[role="alertdialog"]')).toBeVisible()
-    await expect(page.getByText('重複した変数名です')).toBeVisible()
-    await page.locator('button:has-text("OK")').click()
+      // 重複エラーのAlertDialogが表示されることを確認
+      await expect(page.locator('[role="alertdialog"]')).toBeVisible()
+      await expect(page.getByText('重複した変数名です')).toBeVisible()
+      await page.locator('button:has-text("OK")').click()
+    })
   })
 })

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -230,4 +230,92 @@ test.describe('アプリケーション基本動作確認', () => {
     await expect(page.locator('text=E2Eマイグレーションテスト')).toBeVisible()
     await expect(page.locator('text=新しいシート')).toBeVisible()
   })
+
+  test('Variables タブで8つの変数スロットが表示される @step4-1', async ({
+    page,
+  }) => {
+    await page.goto('/')
+
+    // テスト用のシートを追加
+    await page.locator('button:has-text("編集")').click()
+    await page.locator('button:has-text("+")').click()
+    const input = page.locator('[data-testid="new-sheet-input"]')
+    await input.fill('変数テストシート')
+    await input.press('Enter')
+    await page.locator('button:has-text("完了")').click()
+
+    // シートをクリックして詳細画面に遷移
+    await page.locator('text=変数テストシート').click()
+
+    // Variablesタブが表示されることを確認
+    await expect(page.locator('[data-testid="tab-variables"]')).toBeVisible()
+
+    // Variablesタブをクリック
+    await page.locator('[data-testid="tab-variables"]').click()
+
+    // Variable1〜8のラベルが表示されることを確認
+    for (let i = 1; i <= 8; i++) {
+      await expect(page.locator(`text=Variable${i}`)).toBeVisible()
+    }
+
+    // 各スロットに変数名と値の入力フィールドが存在することを確認
+    for (let i = 1; i <= 8; i++) {
+      await expect(
+        page.locator(`[data-testid="variable-name-${i}"]`)
+      ).toBeVisible()
+      await expect(
+        page.locator(`[data-testid="variable-value-${i}"]`)
+      ).toBeVisible()
+    }
+  })
+
+  test('変数名バリデーションが動作する @step4-1', async ({ page }) => {
+    await page.goto('/')
+
+    // テスト用のシートを追加
+    await page.locator('button:has-text("編集")').click()
+    await page.locator('button:has-text("+")').click()
+    const input = page.locator('[data-testid="new-sheet-input"]')
+    await input.fill('バリデーションテストシート')
+    await input.press('Enter')
+    await page.locator('button:has-text("完了")').click()
+
+    // シートをクリックして詳細画面に遷移
+    await page.locator('text=バリデーションテストシート').click()
+
+    // Variablesタブをクリック
+    await page.locator('[data-testid="tab-variables"]').click()
+
+    // 1. 日本語の変数名を入力（不正）
+    const nameInput1 = page.locator(`[data-testid="variable-name-1"]`)
+    await nameInput1.fill('変数名')
+    await nameInput1.blur()
+
+    // AlertDialogが表示されることを確認
+    await expect(page.locator('[role="alertdialog"]')).toBeVisible()
+    await expect(page.getByText('変数名が無効です')).toBeVisible()
+    await page.locator('button:has-text("OK")').click()
+
+    // 2. 数字で始まる変数名を入力（不正）
+    await nameInput1.fill('1variable')
+    await nameInput1.blur()
+
+    // AlertDialogが表示されることを確認
+    await expect(page.locator('[role="alertdialog"]')).toBeVisible()
+    await page.locator('button:has-text("OK")').click()
+
+    // 3. 有効な変数名を入力
+    await nameInput1.fill('validVar')
+    await nameInput1.blur()
+
+    // 4. 同じ変数名を別のスロットに入力（重複）
+    const nameInput2 = page.locator(`[data-testid="variable-name-2"]`)
+    await nameInput2.fill('validVar')
+    await nameInput2.blur()
+
+    // 重複エラーのAlertDialogが表示されることを確認
+    await expect(page.locator('[role="alertdialog"]')).toBeVisible()
+    await expect(page.getByText('重複した変数名です')).toBeVisible()
+    await page.locator('button:has-text("OK")').click()
+  })
 })

--- a/tests/unit/components/TabNavigation.test.tsx
+++ b/tests/unit/components/TabNavigation.test.tsx
@@ -153,8 +153,9 @@ describe('TabNavigation', () => {
     })
 
     it('VariablesTabが正常にレンダリングされる', () => {
+      // VariablesTabはシートIDが必要なので、エラーメッセージが表示されることを確認
       render(<VariablesTab />)
-      expect(screen.getByText('Variables')).toBeInTheDocument()
+      expect(screen.getByText('シートが見つかりません。')).toBeInTheDocument()
     })
 
     it('FormulaTabが正常にレンダリングされる', () => {

--- a/tests/unit/components/VariableSlot.test.tsx
+++ b/tests/unit/components/VariableSlot.test.tsx
@@ -5,6 +5,8 @@ import { VariableSlot } from '@/components/calculator/VariableSlot'
 import type { VariableSlot as VariableSlotType } from '@/types/sheet'
 
 describe('VariableSlot', () => {
+  const VARIABLE_SLOT_COUNT = 8
+
   const mockSlot: VariableSlotType = {
     slot: 1,
     varName: '',
@@ -13,13 +15,16 @@ describe('VariableSlot', () => {
     error: null,
   }
 
-  const mockSlots: VariableSlotType[] = Array.from({ length: 8 }, (_, i) => ({
-    slot: i + 1,
-    varName: '',
-    expression: '',
-    value: null,
-    error: null,
-  }))
+  const mockSlots: VariableSlotType[] = Array.from(
+    { length: VARIABLE_SLOT_COUNT },
+    (_, i) => ({
+      slot: i + 1,
+      varName: '',
+      expression: '',
+      value: null,
+      error: null,
+    })
+  )
 
   const mockOnChange = vi.fn()
   const mockOnValidationError = vi.fn()
@@ -28,19 +33,17 @@ describe('VariableSlot', () => {
     vi.clearAllMocks()
   })
 
-  it('Variable1〜8のラベルが表示される', () => {
-    for (let i = 1; i <= 8; i++) {
-      const slot = { ...mockSlot, slot: i }
-      render(
-        <VariableSlot
-          slot={slot}
-          slots={mockSlots}
-          onChange={mockOnChange}
-          onValidationError={mockOnValidationError}
-        />
-      )
-      expect(screen.getByText(`Variable${i}`)).toBeInTheDocument()
-    }
+  it.each([1, 2, 3, 4, 5, 6, 7, 8])('Variable%iのラベルが表示される', i => {
+    const slot = { ...mockSlot, slot: i }
+    render(
+      <VariableSlot
+        slot={slot}
+        slots={mockSlots}
+        onChange={mockOnChange}
+        onValidationError={mockOnValidationError}
+      />
+    )
+    expect(screen.getByText(`Variable${i}`)).toBeInTheDocument()
   })
 
   it('変数名と値の入力フィールドが表示される', () => {

--- a/tests/unit/components/VariableSlot.test.tsx
+++ b/tests/unit/components/VariableSlot.test.tsx
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { VariableSlot } from '@/components/calculator/VariableSlot'
+import type { VariableSlot as VariableSlotType } from '@/types/sheet'
+
+describe('VariableSlot', () => {
+  const mockSlot: VariableSlotType = {
+    slot: 1,
+    varName: '',
+    expression: '',
+    value: null,
+    error: null,
+  }
+
+  const mockSlots: VariableSlotType[] = Array.from({ length: 8 }, (_, i) => ({
+    slot: i + 1,
+    varName: '',
+    expression: '',
+    value: null,
+    error: null,
+  }))
+
+  const mockOnChange = vi.fn()
+  const mockOnValidationError = vi.fn()
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('Variable1〜8のラベルが表示される', () => {
+    for (let i = 1; i <= 8; i++) {
+      const slot = { ...mockSlot, slot: i }
+      render(
+        <VariableSlot
+          slot={slot}
+          slots={mockSlots}
+          onChange={mockOnChange}
+          onValidationError={mockOnValidationError}
+        />
+      )
+      expect(screen.getByText(`Variable${i}`)).toBeInTheDocument()
+    }
+  })
+
+  it('変数名と値の入力フィールドが表示される', () => {
+    render(
+      <VariableSlot
+        slot={mockSlot}
+        slots={mockSlots}
+        onChange={mockOnChange}
+        onValidationError={mockOnValidationError}
+      />
+    )
+
+    expect(screen.getByTestId('variable-name-1')).toBeInTheDocument()
+    expect(screen.getByTestId('variable-value-1')).toBeInTheDocument()
+  })
+
+  it('変数名入力時にonChangeが呼ばれる', async () => {
+    const user = userEvent.setup()
+    render(
+      <VariableSlot
+        slot={mockSlot}
+        slots={mockSlots}
+        onChange={mockOnChange}
+        onValidationError={mockOnValidationError}
+      />
+    )
+
+    const nameInput = screen.getByTestId('variable-name-1')
+    await user.type(nameInput, 'test')
+
+    expect(mockOnChange).toHaveBeenCalled()
+  })
+
+  it('値入力時にonChangeが呼ばれる', async () => {
+    const user = userEvent.setup()
+    render(
+      <VariableSlot
+        slot={mockSlot}
+        slots={mockSlots}
+        onChange={mockOnChange}
+        onValidationError={mockOnValidationError}
+      />
+    )
+
+    const valueInput = screen.getByTestId('variable-value-1')
+    await user.type(valueInput, '123')
+
+    expect(mockOnChange).toHaveBeenCalled()
+  })
+
+  it('無効な変数名でonValidationErrorが呼ばれる', () => {
+    const slotWithInvalidName = { ...mockSlot, varName: '変数名' }
+    render(
+      <VariableSlot
+        slot={slotWithInvalidName}
+        slots={mockSlots}
+        onChange={mockOnChange}
+        onValidationError={mockOnValidationError}
+      />
+    )
+
+    const nameInput = screen.getByTestId('variable-name-1')
+    fireEvent.blur(nameInput)
+
+    expect(mockOnValidationError).toHaveBeenCalledWith(
+      expect.stringContaining('変数名')
+    )
+  })
+
+  it('重複した変数名でonValidationErrorが呼ばれる', () => {
+    const slotsWithExisting = [
+      { ...mockSlot, slot: 1, varName: 'existingVar' },
+      ...mockSlots.slice(1),
+    ]
+
+    const slotWithDuplicate = { ...mockSlot, slot: 2, varName: 'existingVar' }
+
+    render(
+      <VariableSlot
+        slot={slotWithDuplicate}
+        slots={slotsWithExisting}
+        onChange={mockOnChange}
+        onValidationError={mockOnValidationError}
+      />
+    )
+
+    const nameInput = screen.getByTestId('variable-name-2')
+    fireEvent.blur(nameInput)
+
+    expect(mockOnValidationError).toHaveBeenCalledWith(
+      expect.stringContaining('重複')
+    )
+  })
+
+  it('有効な変数名では onValidationError が呼ばれない', async () => {
+    const user = userEvent.setup()
+    render(
+      <VariableSlot
+        slot={mockSlot}
+        slots={mockSlots}
+        onChange={mockOnChange}
+        onValidationError={mockOnValidationError}
+      />
+    )
+
+    const nameInput = screen.getByTestId('variable-name-1')
+    await user.type(nameInput, 'validVar')
+    fireEvent.blur(nameInput)
+
+    expect(mockOnValidationError).not.toHaveBeenCalled()
+  })
+
+  it('初期値が正しく表示される', () => {
+    const slotWithValues = {
+      ...mockSlot,
+      varName: 'testVar',
+      expression: '123',
+    }
+
+    render(
+      <VariableSlot
+        slot={slotWithValues}
+        slots={mockSlots}
+        onChange={mockOnChange}
+        onValidationError={mockOnValidationError}
+      />
+    )
+
+    expect(screen.getByDisplayValue('testVar')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('123')).toBeInTheDocument()
+  })
+})

--- a/tests/unit/utils/validation.test.ts
+++ b/tests/unit/utils/validation.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest'
+import {
+  isValidVariableName,
+  isDuplicateVariableName,
+} from '@/utils/validation/variableValidation'
+import type { VariableSlot } from '@/types/sheet'
+
+describe('変数名バリデーション', () => {
+  describe('isValidVariableName', () => {
+    it('英字で始まる有効な変数名を許可する', () => {
+      expect(isValidVariableName('validVar')).toBe(true)
+      expect(isValidVariableName('a')).toBe(true)
+      expect(isValidVariableName('A')).toBe(true)
+      expect(isValidVariableName('variable1')).toBe(true)
+      expect(isValidVariableName('var_name')).toBe(true)
+      expect(isValidVariableName('myVariable123')).toBe(true)
+    })
+
+    it('日本語を含む変数名を拒否する', () => {
+      expect(isValidVariableName('変数名')).toBe(false)
+      expect(isValidVariableName('var変数')).toBe(false)
+      expect(isValidVariableName('変数123')).toBe(false)
+    })
+
+    it('数字で始まる変数名を拒否する', () => {
+      expect(isValidVariableName('1variable')).toBe(false)
+      expect(isValidVariableName('123abc')).toBe(false)
+      expect(isValidVariableName('9test')).toBe(false)
+    })
+
+    it('記号を含む変数名を拒否する（アンダースコア以外）', () => {
+      expect(isValidVariableName('var-name')).toBe(false)
+      expect(isValidVariableName('var.name')).toBe(false)
+      expect(isValidVariableName('var+name')).toBe(false)
+      expect(isValidVariableName('var name')).toBe(false)
+      expect(isValidVariableName('var@name')).toBe(false)
+    })
+
+    it('空文字列を許可する', () => {
+      expect(isValidVariableName('')).toBe(true)
+    })
+
+    it('アンダースコアのみで始まる変数名を拒否する', () => {
+      expect(isValidVariableName('_variable')).toBe(false)
+      expect(isValidVariableName('__test')).toBe(false)
+    })
+  })
+
+  describe('isDuplicateVariableName', () => {
+    const mockSlots: VariableSlot[] = [
+      {
+        slot: 1,
+        varName: 'firstVar',
+        expression: '10',
+        value: 10,
+        error: null,
+      },
+      {
+        slot: 2,
+        varName: 'secondVar',
+        expression: '20',
+        value: 20,
+        error: null,
+      },
+      {
+        slot: 3,
+        varName: '',
+        expression: '',
+        value: null,
+        error: null,
+      },
+      {
+        slot: 4,
+        varName: 'fourthVar',
+        expression: '40',
+        value: 40,
+        error: null,
+      },
+    ]
+
+    it('重複する変数名を検出する', () => {
+      expect(isDuplicateVariableName('firstVar', 3, mockSlots)).toBe(true)
+      expect(isDuplicateVariableName('secondVar', 4, mockSlots)).toBe(true)
+      expect(isDuplicateVariableName('fourthVar', 1, mockSlots)).toBe(true)
+    })
+
+    it('同じスロットの名前は重複として扱わない', () => {
+      expect(isDuplicateVariableName('firstVar', 1, mockSlots)).toBe(false)
+      expect(isDuplicateVariableName('secondVar', 2, mockSlots)).toBe(false)
+      expect(isDuplicateVariableName('fourthVar', 4, mockSlots)).toBe(false)
+    })
+
+    it('新しい変数名は重複しない', () => {
+      expect(isDuplicateVariableName('newVar', 3, mockSlots)).toBe(false)
+      expect(isDuplicateVariableName('uniqueName', 1, mockSlots)).toBe(false)
+    })
+
+    it('空文字列は重複チェック不要', () => {
+      expect(isDuplicateVariableName('', 1, mockSlots)).toBe(false)
+      expect(isDuplicateVariableName('', 3, mockSlots)).toBe(false)
+    })
+
+    it('大文字小文字を区別する', () => {
+      expect(isDuplicateVariableName('FIRSTVAR', 3, mockSlots)).toBe(false)
+      expect(isDuplicateVariableName('FirstVar', 3, mockSlots)).toBe(false)
+    })
+  })
+})


### PR DESCRIPTION
## 目的 / 関連ステップ
Step4-1: Variablesタブでの8つの変数スロット表示とバリデーション機能の実装

## 実装内容
- Variable1〜8の8つの変数スロット表示
- 変数名と値の入力フィールド
- 正規表現による変数名バリデーション
- 同一シート内での変数名重複チェック
- AlertDialogによる入力エラー表示
- TDDアプローチによるテスト実装

## 動作確認内容
- 全193テストが正常に通過
- lint/format/buildでエラー・警告なし
- 開発サーバー正常起動確認

## 備考
Close #67

🤖 Generated with [Claude Code](https://claude.ai/code)