### PR TITLE
Normalize fraction conversion and prefix rendered expressions with "= "

### DIFF
--- a/src/components/calculator/ExpressionRenderer.tsx
+++ b/src/components/calculator/ExpressionRenderer.tsx
@@ -25,8 +25,8 @@ export function ExpressionRenderer({ expression, className }: Props) {
   const line3Ref = useRef<HTMLDivElement>(null)
 
   const hasFunction = usesFunctions(expression)
-  const latexWithoutFn = convertToLatexWithoutFunctionNames(expression)
-  const latexWithFn = convertToLatexWithFunctionNames(expression)
+  const latexWithoutFn = `= ${convertToLatexWithoutFunctionNames(expression)}`
+  const latexWithFn = `= ${convertToLatexWithFunctionNames(expression)}`
 
   // KaTeXでレンダリング
   useEffect(() => {
@@ -59,7 +59,7 @@ export function ExpressionRenderer({ expression, className }: Props) {
     <div className={className}>
       {/* 1行目：元の式 */}
       <div className="font-mono text-sm whitespace-pre-wrap break-all">
-        {expression}
+        {`= ${expression}`}
       </div>
 
       {/* 2行目：関数名そのまま（関数使用時のみ） */}

--- a/src/utils/calculation/latexConverter.ts
+++ b/src/utils/calculation/latexConverter.ts
@@ -95,8 +95,11 @@ function convertToCustomLatex(
   // 6. モジュロ演算子の変換
   result = result.replace(/\s*%\s*/g, ' \\bmod ')
 
-  // 6.5. Issue #96 の分数化不具合ホットフィックス
-  result = applyIssue96Hotfixes(result)
+  // 6.5. 基本分数の正規化（a/(\frac{b}{c})）
+  result = result.replace(
+    /([^\s/()]+)\s*\/\s*\((\\frac\{[^{}]+\}\{[^{}]+\})\)/g,
+    '\\frac{$1}{$2}'
+  )
 
   // 7. 重複した度記号の削除
   result = result.replace(/°°+/g, '°')
@@ -145,37 +148,6 @@ function convertPowers(expression: string): string {
     result += '^'
   }
 
-  return result
-}
-
-
-
-function applyIssue96Hotfixes(expression: string): string {
-  let result = expression
-  result = result.replace(
-    /1\s*\/\s*\((\\frac\{[^{}]+\}\{[^{}]+\})\)/g,
-    '\\frac{1}{$1}'
-  )
-  result = result.replace(
-    /2\s*\/\s*\((3\\times\s*4)\)/g,
-    '\\frac{2}{($1)}'
-  )
-  result = result.replace(
-    /\\frac\{\(2\+1\)\\frac\{\}\{3\}\}\{4\}/g,
-    '\\frac{\\frac{(2+1)}{3}}{4}'
-  )
-  result = result.replace(
-    /\\frac\{\\log_\{10\}\(\(9-1\)\}\{8\}\)/g,
-    '\\log_{10}(\\frac{(9-1)}{8})'
-  )
-  result = result.replace(
-    /\\sqrt\{\\frac\{2\}\{3\\times\s*\}\s*4\}/g,
-    '\\sqrt{\\frac{2}{3}\\times 4}'
-  )
-  result = result.replace(
-    /\\sin\(\\frac\{2\}\{3-4\}°\)/g,
-    '\\sin(\\frac{2}{3}-4°)'
-  )
   return result
 }
 // 関数名変換（3行目のみ）
@@ -310,19 +282,13 @@ function convertFractions(
     )
   }
 
-  // 4. 関数 / 項
-  result = result.replace(
-    /(\w+\([^)]+\)(?:\^{[^}]+})?)\s*\/\s*([^\s/()]+)/g,
-    '\\frac{$1}{$2}'
-  )
-
-  // 5. 括弧式 / 項
+  // 4. 括弧式 / 項
   result = result.replace(
     /(\([^)]+\)(?:\^{[^}]+})?)\s*\/\s*(\w+\([^)]*\)(?:\^\{[^}]+\})?|[^\s/()+\-*]+)/g,
     '\\frac{$1}{$2}'
   )
 
-  // 6. 演算子優先順位を考慮した基本分数
+  // 5. 演算子優先順位を考慮した基本分数
   result = convertBasicFractions(result)
   if (convertFunctions) {
     result = result.replace(
@@ -341,6 +307,17 @@ function convertFractions(
 // 基本的な分数変換（左結合性を考慮）
 function convertBasicFractions(expression: string): string {
   let result = expression
+
+  // パターン-1: (a)/b/c の左結合
+  result = result.replace(
+    /\(([^()]+)\)\s*\/\s*([^\s/()]+)\s*\/\s*([^\s/()]+)/g,
+    '\\frac{\\frac{($1)}{$2}}{$3}'
+  )
+  // パターン-1b: a/(b/c) の左結合
+  result = result.replace(
+    /([^\s/()]+)\s*\/\s*\((\\frac\{.+?\}\{.+?\})\)/g,
+    '\\frac{$1}{$2}'
+  )
 
   // パターン0: a/b*c/d の連鎖を左結合で分数化
   // 例: 5/4*3/2 → \frac{5}{4}\times \frac{3}{2}
@@ -384,6 +361,16 @@ function convertBasicFractions(expression: string): string {
     '\\frac{$1}{$2}'
   )
 
+  // パターン3b: 項 / (複合式)
+  result = result.replace(
+    /([^\s/()]+)\s*\/\s*(\([^()]*\\times[^()]*\))/g,
+    '\\frac{$1}{$2}'
+  )
+  result = result.replace(
+    /([^\s/()]+)\s*\/\s*(\(\\frac\{[^{}]+\}\{[^{}]+\}\))/g,
+    '\\frac{$1}{$2}'
+  )
+
   // パターン4: 基本的な分数（左結合性を保持）
   // 6/2*4 は 6/2 のみを分数にして、*4 は外に残す
   // 8/4/2 は 8/4 のみを分数にして、/2 は外に残す
@@ -398,6 +385,11 @@ function convertBasicFractions(expression: string): string {
   result = result.replace(
     /(\\frac\{[^{}]+\}\{[^{}]+\})\s*\/\s*([^\s/()]+)/g,
     '\\frac{$1}{$2}'
+  )
+  // パターン5: 変換途中で崩れた入れ子分数の正規化
+  result = result.replace(
+    /\\frac\{\(([^)]+)\)\\frac\{\}\{([^}]+)\}\}\{([^}]+)\}/g,
+    '\\frac{\\frac{($1)}{$2}}{$3}'
   )
 
   return result
@@ -441,6 +433,12 @@ function replaceFunctionArgsWithFractions(
         // まず \times を * に戻して統一的に処理
         convertedArgs = convertedArgs.replace(/\\times/g, '*')
 
+        // パターン0: (式)/項
+        convertedArgs = convertedArgs.replace(
+          /^\((.+)\)\s*\/\s*([^\s/()]+)$/g,
+          '\\frac{($1)}{$2}'
+        )
+
         // パターン1: 乗算チェーン * 変数 / 単項 の特別処理
         // 例: 2*[var1]/[var2] → 2*\frac{[var1]}{[var2]} (先頭の係数を外に出す)
         convertedArgs = convertedArgs.replace(
@@ -477,7 +475,7 @@ function replaceFunctionArgsWithFractions(
 
         // パターン4: 基本的な分数（関数呼び出し以外）
         convertedArgs = convertedArgs.replace(
-          /([^\s/()]+)\s*\/\s*([^\s/()]+)/g,
+          /([^\s/()+*-]+)\s*\/\s*([^\s/()+*-]+)/g,
           '\\frac{$1}{$2}'
         )
 

--- a/tests/unit/components/ExpressionRenderer.test.tsx
+++ b/tests/unit/components/ExpressionRenderer.test.tsx
@@ -26,16 +26,16 @@ describe('ExpressionRenderer', () => {
     render(<ExpressionRenderer expression={expression} />)
 
     // 1行目：元の式
-    expect(screen.getByText(expression)).toBeInTheDocument()
+    expect(screen.getByText(`= ${expression}`)).toBeInTheDocument()
 
     // 2行目：関数名そのまま版（KaTeX）
     expect(
-      screen.getByText('KATEX[atan(2\\times \\frac{[var1]}{[var2]})]')
+      screen.getByText('KATEX[= atan(2\\times \\frac{[var1]}{[var2]})]')
     ).toBeInTheDocument()
 
     // 3行目：関数名変換版（KaTeX）
     expect(
-      screen.getByText('KATEX[\\tan^{-1}(2\\times \\frac{[var1]}{[var2]})°]')
+      screen.getByText('KATEX[= \\tan^{-1}(2\\times \\frac{[var1]}{[var2]})°]')
     ).toBeInTheDocument()
   })
 
@@ -45,10 +45,10 @@ describe('ExpressionRenderer', () => {
     const { container } = render(<ExpressionRenderer expression={expression} />)
 
     // 1行目：元の式
-    expect(screen.getByText(expression)).toBeInTheDocument()
+    expect(screen.getByText(`= ${expression}`)).toBeInTheDocument()
 
     // 3行目：関数名変換版のみ表示（加算はそのまま）
-    expect(screen.getByText('KATEX[2 + 3]')).toBeInTheDocument()
+    expect(screen.getByText('KATEX[= 2 + 3]')).toBeInTheDocument()
 
     // 2行目は表示されない（divが2つのみ）
     const childDivs = container.children[0].children
@@ -61,11 +61,11 @@ describe('ExpressionRenderer', () => {
     const { container } = render(<ExpressionRenderer expression={expression} />)
 
     // 1行目：元の式
-    expect(screen.getByText(expression)).toBeInTheDocument()
+    expect(screen.getByText(`= ${expression}`)).toBeInTheDocument()
 
     // 3行目のみ表示（関数なしと判定される）
     expect(
-      screen.getByText('KATEX[random(1,10) + \\pi\\times e]')
+      screen.getByText('KATEX[= random(1,10) + \\pi\\times e]')
     ).toBeInTheDocument()
 
     // 2行目は表示されない
@@ -78,13 +78,13 @@ describe('ExpressionRenderer', () => {
 
     // KaTeXのrenderが呼ばれることを確認
     expect(renderMock).toHaveBeenCalledWith(
-      'sin(30)',
+      '= sin(30)',
       expect.any(HTMLElement),
       { throwOnError: false, displayMode: false }
     )
 
     expect(renderMock).toHaveBeenCalledWith(
-      '\\sin(30°)',
+      '= \\sin(30°)',
       expect.any(HTMLElement),
       { throwOnError: false, displayMode: false }
     )
@@ -102,7 +102,7 @@ describe('ExpressionRenderer', () => {
     render(<ExpressionRenderer expression="sin(30)" />)
 
     // エラー時は元のLaTeX文字列が表示される（複数箇所に表示される）
-    const elements = screen.getAllByText('sin(30)')
+    const elements = screen.getAllByText('= sin(30)')
     expect(elements).toHaveLength(2) // 1行目と2行目（エラーフォールバック）
 
     // 警告が呼ばれたことを確認
@@ -137,16 +137,16 @@ describe('ExpressionRenderer', () => {
     render(<ExpressionRenderer expression={expression} />)
 
     // 1行目：元の式
-    expect(screen.getByText(expression)).toBeInTheDocument()
+    expect(screen.getByText(`= ${expression}`)).toBeInTheDocument()
 
     // 2行目：関数名そのまま版
     expect(
-      screen.getByText('KATEX[sqrt(log(100\\times [var1]))]')
+      screen.getByText('KATEX[= sqrt(log(100\\times [var1]))]')
     ).toBeInTheDocument()
 
     // 3行目：関数名変換版
     expect(
-      screen.getByText('KATEX[\\sqrt{\\log_{10}(100\\times [var1])}]')
+      screen.getByText('KATEX[= \\sqrt{\\log_{10}(100\\times [var1])}]')
     ).toBeInTheDocument()
   })
 })

--- a/tests/unit/utils/latexConverter.test.ts
+++ b/tests/unit/utils/latexConverter.test.ts
@@ -353,30 +353,47 @@ describe('latexConverter', () => {
     })
   })
 
-
   describe('Issue #96 追加ケース', () => {
     it('sin(2/3-4) を正しく変換する', () => {
-      expect(convertToLatexWithFunctionNames('sin(2/3-4)')).toBe('\\sin(\\frac{2}{3}-4°)')
+      expect(convertToLatexWithFunctionNames('sin(2/3-4)')).toBe(
+        '\\sin(\\frac{2}{3}-4°)'
+      )
     })
 
     it('1/(2/3) を正しく変換する', () => {
-      expect(convertToLatexWithFunctionNames('1/(2/3)')).toBe('\\frac{1}{\\frac{2}{3}}')
+      expect(convertToLatexWithFunctionNames('1/(2/3)')).toBe(
+        '\\frac{1}{\\frac{2}{3}}'
+      )
     })
 
     it('2/(3*4) を正しく変換する', () => {
-      expect(convertToLatexWithFunctionNames('2/(3*4)')).toBe('\\frac{2}{(3\\times 4)}')
+      expect(convertToLatexWithFunctionNames('2/(3*4)')).toBe(
+        '\\frac{2}{(3\\times 4)}'
+      )
     })
 
     it('(2+1)/3/4 を正しく変換する', () => {
-      expect(convertToLatexWithFunctionNames('(2+1)/3/4')).toBe('\\frac{\\frac{(2+1)}{3}}{4}')
+      expect(convertToLatexWithFunctionNames('(2+1)/3/4')).toBe(
+        '\\frac{\\frac{(2+1)}{3}}{4}'
+      )
     })
 
     it('log((9-1)/8) を正しく変換する', () => {
-      expect(convertToLatexWithFunctionNames('log((9-1)/8)')).toBe('\\log_{10}(\\frac{(9-1)}{8})')
+      expect(convertToLatexWithFunctionNames('log((9-1)/8)')).toBe(
+        '\\log_{10}(\\frac{(9-1)}{8})'
+      )
     })
 
     it('sqrt(2/3*4) を正しく変換する', () => {
-      expect(convertToLatexWithFunctionNames('sqrt(2/3*4)')).toBe('\\sqrt{\\frac{2}{3}\\times 4}')
+      expect(convertToLatexWithFunctionNames('sqrt(2/3*4)')).toBe(
+        '\\sqrt{\\frac{2}{3}\\times 4}'
+      )
+    })
+
+    it('sqrt(2/3*4) の2行目用変換を正しく処理する', () => {
+      expect(convertToLatexWithoutFunctionNames('sqrt(2/3*4)')).toBe(
+        'sqrt(\\frac{2}{3}\\times 4)'
+      )
     })
   })
 })


### PR DESCRIPTION
### Motivation
- Improve LaTeX conversion reliability for nested and compound fraction patterns and remove brittle hotfixes that handled specific Issue #96 cases.
- Make rendered expressions visually consistent by prefixing displayed lines with a leading `= ` so output matches UI expectations.

### Description
- Prefixes displayed expressions in `ExpressionRenderer` by adding `= ` to the original expression and both LaTeX variants (`latexWithoutFn` and `latexWithFn`) before KaTeX rendering. 
- Reworks fraction handling in `latexConverter.ts` by removing the ad-hoc `applyIssue96Hotfixes` and adding normalization and stricter/expanded regexes to handle cases like `a/(b/c)`, nested fractions, left-associative chaining `(a)/b/c`, and multiplication/division chains. 
- Enhances `convertBasicFractions`, `convertPowers`, `replaceFunctionArgsWithFractions`, and `convertFractions` to better normalize intermediate states and preserve operator precedence. 
- Adds/adjusts unit test expectations to account for the `= ` prefix and verifies additional fraction conversion scenarios including a new check for the second-line conversion of `sqrt(2/3*4)`.

### Testing
- Ran unit tests in `tests/unit/components/ExpressionRenderer.test.tsx` which were updated to expect the `= ` prefix and all assertions passed. 
- Ran unit tests in `tests/unit/utils/latexConverter.test.ts` including the Issue #96 related cases and the new `sqrt(2/3*4)` second-line check, and they passed.

close #98 
------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9e54d8a8083318f736d09c2b0966d)