### PR TITLE
fix/step6-2: LaTeX分数変換の括弧崩れを修正

### DIFF
--- a/src/utils/calculation/latexConverter.ts
+++ b/src/utils/calculation/latexConverter.ts
@@ -249,6 +249,11 @@ function convertFractions(
   expression: string,
   convertFunctions: boolean = false
 ): string {
+  const structuralResult = convertFractionsStructurally(expression)
+  if (structuralResult !== null) {
+    return structuralResult
+  }
+
   let result = expression
 
   // 1. 関数の引数内での分数変換（最優先で処理）
@@ -302,6 +307,306 @@ function convertFractions(
   }
 
   return result
+}
+
+type FractionAstNode =
+  | { type: 'raw'; value: string }
+  | { type: 'unary'; operator: '-'; value: FractionAstNode }
+  | {
+      type: 'binary'
+      operator: '+' | '-' | '*' | '/'
+      left: FractionAstNode
+      right: FractionAstNode
+    }
+  | { type: 'paren'; value: FractionAstNode }
+  | { type: 'function'; name: string; args: FractionAstNode[] }
+
+type FractionToken =
+  | { type: 'raw'; value: string }
+  | { type: 'operator'; value: '+' | '-' | '*' | '/' }
+  | { type: 'paren'; value: '(' | ')' }
+  | { type: 'comma'; value: ',' }
+
+function convertFractionsStructurally(expression: string): string | null {
+  if (!shouldUseStructuralFractionConverter(expression)) {
+    return null
+  }
+
+  const tokens = tokenizeFractionExpression(expression)
+  if (tokens === null) {
+    return null
+  }
+
+  const parser = new FractionExpressionParser(tokens)
+  const ast = parser.parse()
+  if (ast === null || !parser.isAtEnd()) {
+    return null
+  }
+
+  return formatFractionAst(ast)
+}
+
+function shouldUseStructuralFractionConverter(expression: string): boolean {
+  if (!expression.includes('/') || expression.includes('[')) {
+    return false
+  }
+
+  if (expression.includes('pi')) {
+    return false
+  }
+
+  return (
+    expression.startsWith('((') ||
+    /\/\s*\(\(/.test(expression) ||
+    /\/\s*\([^()]*\/[^()]*\)/.test(expression) ||
+    /\b(?:sin|cos|tan|asin|acos|atan|sqrt|log|ln|exp|dtor|rtod)\([^)]*\)\s*[+-]/.test(
+      expression
+    )
+  )
+}
+
+function tokenizeFractionExpression(
+  expression: string
+): FractionToken[] | null {
+  const tokens: FractionToken[] = []
+  let index = 0
+
+  while (index < expression.length) {
+    const current = expression[index]
+
+    if (/\s/.test(current)) {
+      index++
+      continue
+    }
+
+    if (current === '\\' && expression.startsWith('\\times', index)) {
+      tokens.push({ type: 'operator', value: '*' })
+      index += '\\times'.length
+      continue
+    }
+
+    if (
+      current === '+' ||
+      current === '-' ||
+      current === '*' ||
+      current === '/'
+    ) {
+      tokens.push({ type: 'operator', value: current })
+      index++
+      continue
+    }
+
+    if (current === '(' || current === ')') {
+      tokens.push({ type: 'paren', value: current })
+      index++
+      continue
+    }
+
+    if (current === ',') {
+      tokens.push({ type: 'comma', value: current })
+      index++
+      continue
+    }
+
+    let endIndex = index
+    while (endIndex < expression.length) {
+      const char = expression[endIndex]
+      if (
+        /\s/.test(char) ||
+        char === '(' ||
+        char === ')' ||
+        char === ',' ||
+        char === '/' ||
+        char === '*'
+      ) {
+        break
+      }
+
+      if ((char === '+' || char === '-') && endIndex > index) {
+        const previous = expression[endIndex - 1]
+        if (previous !== '^') {
+          break
+        }
+      }
+
+      endIndex++
+    }
+
+    if (endIndex === index) {
+      return null
+    }
+
+    tokens.push({ type: 'raw', value: expression.slice(index, endIndex) })
+    index = endIndex
+  }
+
+  return tokens
+}
+
+class FractionExpressionParser {
+  private current = 0
+  private readonly tokens: FractionToken[]
+
+  constructor(tokens: FractionToken[]) {
+    this.tokens = tokens
+  }
+
+  parse(): FractionAstNode | null {
+    return this.parseAdditive()
+  }
+
+  isAtEnd(): boolean {
+    return this.current >= this.tokens.length
+  }
+
+  private parseAdditive(): FractionAstNode | null {
+    let node = this.parseMultiplicative()
+    if (node === null) return null
+
+    while (this.matchOperator('+') || this.matchOperator('-')) {
+      const operator = this.previous().value as '+' | '-'
+      const right = this.parseMultiplicative()
+      if (right === null) return null
+      node = { type: 'binary', operator, left: node, right }
+    }
+
+    return node
+  }
+
+  private parseMultiplicative(): FractionAstNode | null {
+    let node = this.parseUnary()
+    if (node === null) return null
+
+    while (this.matchOperator('*') || this.matchOperator('/')) {
+      const operator = this.previous().value as '*' | '/'
+      const right = this.parseUnary()
+      if (right === null) return null
+      node = { type: 'binary', operator, left: node, right }
+    }
+
+    return node
+  }
+
+  private parseUnary(): FractionAstNode | null {
+    if (this.matchOperator('-')) {
+      const value = this.parseUnary()
+      if (value === null) return null
+      return { type: 'unary', operator: '-', value }
+    }
+
+    return this.parsePrimary()
+  }
+
+  private parsePrimary(): FractionAstNode | null {
+    if (this.matchRaw()) {
+      const rawToken = this.previous()
+      if (rawToken.type !== 'raw') return null
+
+      if (this.matchParen('(')) {
+        const args = this.parseFunctionArgs()
+        if (args === null) return null
+        return { type: 'function', name: rawToken.value, args }
+      }
+
+      return { type: 'raw', value: rawToken.value }
+    }
+
+    if (this.matchParen('(')) {
+      const value = this.parseAdditive()
+      if (value === null || !this.matchParen(')')) {
+        return null
+      }
+      return { type: 'paren', value }
+    }
+
+    return null
+  }
+
+  private parseFunctionArgs(): FractionAstNode[] | null {
+    const args: FractionAstNode[] = []
+    if (this.matchParen(')')) {
+      return args
+    }
+
+    do {
+      const arg = this.parseAdditive()
+      if (arg === null) return null
+      args.push(arg)
+    } while (this.matchComma())
+
+    if (!this.matchParen(')')) {
+      return null
+    }
+
+    return args
+  }
+
+  private matchOperator(operator: FractionToken['value']): boolean {
+    const token = this.peek()
+    if (token?.type !== 'operator' || token.value !== operator) {
+      return false
+    }
+    this.current++
+    return true
+  }
+
+  private matchParen(paren: '(' | ')'): boolean {
+    const token = this.peek()
+    if (token?.type !== 'paren' || token.value !== paren) {
+      return false
+    }
+    this.current++
+    return true
+  }
+
+  private matchRaw(): boolean {
+    if (this.peek()?.type !== 'raw') {
+      return false
+    }
+    this.current++
+    return true
+  }
+
+  private matchComma(): boolean {
+    if (this.peek()?.type !== 'comma') {
+      return false
+    }
+    this.current++
+    return true
+  }
+
+  private peek(): FractionToken | undefined {
+    return this.tokens[this.current]
+  }
+
+  private previous(): FractionToken {
+    return this.tokens[this.current - 1]
+  }
+}
+
+function formatFractionAst(node: FractionAstNode): string {
+  switch (node.type) {
+    case 'raw':
+      return node.value
+    case 'unary':
+      return `-${formatFractionAst(node.value)}`
+    case 'paren':
+      return `(${formatFractionAst(node.value)})`
+    case 'function':
+      return `${node.name}(${node.args.map(formatFractionAst).join(', ')})`
+    case 'binary':
+      if (node.operator === '/') {
+        return `\\frac{${formatFractionAst(node.left)}}{${formatFractionAst(node.right)}}`
+      }
+      return `${formatFractionAst(node.left)}${formatFractionOperator(node.operator)}${formatFractionAst(node.right)}`
+  }
+}
+
+function formatFractionOperator(operator: '+' | '-' | '*'): string {
+  if (operator === '*') {
+    return '\\times '
+  }
+  return operator
 }
 
 // 基本的な分数変換（左結合性を考慮）

--- a/src/utils/calculation/latexConverter.ts
+++ b/src/utils/calculation/latexConverter.ts
@@ -347,11 +347,7 @@ function convertFractionsStructurally(expression: string): string | null {
 }
 
 function shouldUseStructuralFractionConverter(expression: string): boolean {
-  if (!expression.includes('/') || expression.includes('[')) {
-    return false
-  }
-
-  if (expression.includes('pi')) {
+  if (!expression.includes('/')) {
     return false
   }
 
@@ -359,7 +355,7 @@ function shouldUseStructuralFractionConverter(expression: string): boolean {
     expression.startsWith('((') ||
     /\/\s*\(\(/.test(expression) ||
     /\/\s*\([^()]*\/[^()]*\)/.test(expression) ||
-    /\b(?:sin|cos|tan|asin|acos|atan|sqrt|log|ln|exp|dtor|rtod)\([^)]*\)\s*[+-]/.test(
+    /\([^)]*\b(?:sin|cos|tan|asin|acos|atan|sqrt|log|ln|exp|dtor|rtod)\([^)]*\)[^)]*[+-][^)]*\)\s*\//.test(
       expression
     )
   )
@@ -424,7 +420,7 @@ function tokenizeFractionExpression(
 
       if ((char === '+' || char === '-') && endIndex > index) {
         const previous = expression[endIndex - 1]
-        if (previous !== '^') {
+        if (previous !== '^' && previous !== '{') {
           break
         }
       }

--- a/tests/unit/utils/latexConverter.test.ts
+++ b/tests/unit/utils/latexConverter.test.ts
@@ -427,5 +427,23 @@ describe('latexConverter', () => {
         '\\frac{1}{(\\frac{\\frac{2}{3}}{4})}'
       )
     })
+
+    it('変数を含むネスト括弧の分数を正しく変換する', () => {
+      expect(convertToLatexWithFunctionNames('(([var1]+1)/([var2]+2))/5')).toBe(
+        '\\frac{(\\frac{([var1]+1)}{([var2]+2)})}{5}'
+      )
+    })
+
+    it('pi定数を含むネスト括弧の分数を正しく変換する', () => {
+      expect(convertToLatexWithFunctionNames('((pi()+1)/(3+4))/5')).toBe(
+        '\\frac{(\\frac{(\\pi+1)}{(3+4)})}{5}'
+      )
+    })
+
+    it('負の指数を含むネスト括弧の分数を正しく変換する', () => {
+      expect(convertToLatexWithFunctionNames('(([x]^-2+1)/([y]^-3+2))/5')).toBe(
+        '\\frac{(\\frac{([x]^{-2}+1)}{([y]^{-3}+2)})}{5}'
+      )
+    })
   })
 })

--- a/tests/unit/utils/latexConverter.test.ts
+++ b/tests/unit/utils/latexConverter.test.ts
@@ -362,7 +362,7 @@ describe('latexConverter', () => {
 
     it('1/(2/3) を正しく変換する', () => {
       expect(convertToLatexWithFunctionNames('1/(2/3)')).toBe(
-        '\\frac{1}{\\frac{2}{3}}'
+        '\\frac{1}{(\\frac{2}{3})}'
       )
     })
 
@@ -393,6 +393,38 @@ describe('latexConverter', () => {
     it('sqrt(2/3*4) の2行目用変換を正しく処理する', () => {
       expect(convertToLatexWithoutFunctionNames('sqrt(2/3*4)')).toBe(
         'sqrt(\\frac{2}{3}\\times 4)'
+      )
+    })
+  })
+
+  describe('Issue #100 追加ケース', () => {
+    it('ネスト括弧を含む分数を正しく変換する', () => {
+      expect(convertToLatexWithFunctionNames('((1+2)/(3+4))/5')).toBe(
+        '\\frac{(\\frac{(1+2)}{(3+4)})}{5}'
+      )
+    })
+
+    it('二重括弧と乗算を含む複合分母を正しく変換する', () => {
+      expect(convertToLatexWithFunctionNames('1/((2+3)*4)')).toBe(
+        '\\frac{1}{((2+3)\\times 4)}'
+      )
+    })
+
+    it('関数を含む和差どうしの除算を正しく変換する', () => {
+      expect(convertToLatexWithFunctionNames('(sin(12)+1)/(cos(34)+1)')).toBe(
+        '\\frac{(\\sin(12°)+1)}{(\\cos(34°)+1)}'
+      )
+    })
+
+    it('括弧付き左結合多段除算を正しく変換する', () => {
+      expect(convertToLatexWithFunctionNames('((2+1)/3)/4')).toBe(
+        '\\frac{(\\frac{(2+1)}{3})}{4}'
+      )
+    })
+
+    it('入れ子分数を分母に持つ一般形を正しく変換する', () => {
+      expect(convertToLatexWithFunctionNames('1/(2/3/4)')).toBe(
+        '\\frac{1}{(\\frac{\\frac{2}{3}}{4})}'
       )
     })
   })


### PR DESCRIPTION
### Motivation
- ネスト括弧・複合分母・関数を含む和差同士の除算で LaTeX 表示時に括弧構造が崩れる不具合を修正するため、Issue #100 に対応した。 
- 既存の正規表現ベース変換の互換性を保ちつつ、正規表現では扱いにくい構造のみ安全に処理する必要があった。 

### Description
- `src/utils/calculation/latexConverter.ts` にトークン化 → 構文解析（AST） → LaTeX 出力の経路を追加し、問題のある分数構造を構造ベースで変換する関数群（`tokenizeFractionExpression` / `FractionExpressionParser` / `formatFractionAst` 等）を実装した。 
- `convertFractions` に構造ベースの変換を優先的に試す分岐を追加し、対象判定は `shouldUseStructuralFractionConverter` で限定して既存挙動を壊さないようにした。 
- テスト `tests/unit/utils/latexConverter.test.ts` を更新し、`1/(2/3)` の期待値を分母側括弧を保持する形に修正するとともに Issue #100 の再現ケース群を追加した。 

### Testing
- `npm run test:unit tests/unit/utils/latexConverter.test.ts` を実行し該当ユニットテストはすべて成功（43 tests）。 
- リポジトリの全ユニットテスト `npm run test` と Playwright E2E を含むチェックを実行し、ユニット360 tests 全て成功および E2E 44 tests 全て成功した。 
- `npm run lint` / `npm run format` / `npm run build` / `npm run check` を実行して問題なく通過した。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69faa98f0b8c8331b857e57f125bdeed)

Close #100