### PR TITLE
LaTeX変換: 1/(a+b) 分数化・べき乗連鎖の右結合化・atan 表示の改善

### DIFF
--- a/src/utils/calculation/latexConverter.ts
+++ b/src/utils/calculation/latexConverter.ts
@@ -444,6 +444,8 @@ function formatStructuralLatexFunction(
   )
   const firstArg = args[0] ?? ''
   const useScaledParens = firstArg.includes('\\frac{')
+  const useScaledParensForAtan =
+    useScaledParens && !firstArg.includes('\\times')
   const wrapParens = (content: string): string =>
     useScaledParens ? `\\left(${content}\\right)` : `(${content})`
 
@@ -475,7 +477,7 @@ function formatStructuralLatexFunction(
         ? `\\cos^{-1}\\left(${firstArg}\\right)°`
         : `\\cos^{-1}(${firstArg})°`
     case 'atan':
-      return useScaledParens
+      return useScaledParensForAtan
         ? `\\tan^{-1}\\left(${firstArg}\\right)°`
         : `\\tan^{-1}(${firstArg})°`
     case 'dtor':
@@ -508,7 +510,7 @@ function convertPowers(expression: string): string {
         return { value: expression.slice(start, end), end }
       }
 
-      const tokenMatch = expression.slice(start).match(/^-?[\d.a-zA-Z[\]_]+/)
+      const tokenMatch = expression.slice(start).match(/^-?[\d.a-zA-Z[\]_\\]+/)
       if (!tokenMatch) return null
       return { value: tokenMatch[0], end: start + tokenMatch[0].length }
     }

--- a/src/utils/calculation/latexConverter.ts
+++ b/src/utils/calculation/latexConverter.ts
@@ -489,6 +489,42 @@ function formatStructuralLatexFunction(
 
 // べき乗変換の改良版
 function convertPowers(expression: string): string {
+  const parseExponent = (
+    start: number
+  ): { value: string; end: number } | null => {
+    const next = expression[start]
+    if (!next) return null
+
+    const parseAtomic = (): { value: string; end: number } | null => {
+      if (next === '(') {
+        let depth = 1
+        let end = start + 1
+        while (end < expression.length && depth > 0) {
+          if (expression[end] === '(') depth++
+          if (expression[end] === ')') depth--
+          end++
+        }
+        if (depth !== 0) return null
+        return { value: expression.slice(start, end), end }
+      }
+
+      const tokenMatch = expression.slice(start).match(/^-?[\d.a-zA-Z[\]_]+/)
+      if (!tokenMatch) return null
+      return { value: tokenMatch[0], end: start + tokenMatch[0].length }
+    }
+
+    const atomic = parseAtomic()
+    if (atomic === null) return null
+
+    if (expression[atomic.end] !== '^') {
+      return atomic
+    }
+
+    const rhs = parseExponent(atomic.end + 1)
+    if (rhs === null) return atomic
+    return { value: `${atomic.value}^{${rhs.value}}`, end: rhs.end }
+  }
+
   let result = ''
   for (let i = 0; i < expression.length; i++) {
     const current = expression[i]
@@ -497,32 +533,14 @@ function convertPowers(expression: string): string {
       continue
     }
 
-    const next = expression[i + 1]
-    if (next === '(') {
-      let depth = 1
-      let j = i + 2
-      while (j < expression.length && depth > 0) {
-        if (expression[j] === '(') depth++
-        if (expression[j] === ')') depth--
-        j++
-      }
-
-      if (depth === 0) {
-        const content = expression.slice(i + 1, j) // "(...)"
-        result += `^{${content}}`
-        i = j - 1
-        continue
-      }
-    }
-
-    const match = expression.slice(i + 1).match(/^-?[\d.a-zA-Z[\]_]+/)
-    if (match) {
-      result += `^{${match[0]}}`
-      i += match[0].length
+    const exponent = parseExponent(i + 1)
+    if (exponent === null) {
+      result += '^'
       continue
     }
 
-    result += '^'
+    result += `^{${exponent.value}}`
+    i = exponent.end - 1
   }
 
   return result
@@ -1036,6 +1054,12 @@ function convertBasicFractions(expression: string): string {
   // 例: [x]/sqrt([x]^2+[y]^2) → \frac{[x]}{sqrt([x]^{2}+[y]^{2})}
   result = result.replace(
     /([^\s/()]+)\s*\/\s*(\w+\([^)]*\)(?:\^\{[^}]+\})?)(?=\s*(?:\\times|\/|[+-]|$))/g,
+    '\\frac{$1}{$2}'
+  )
+
+  // パターン3a: 項 / (加減算を含む式)
+  result = result.replace(
+    /([^\s/()+*-]+)\s*\/\s*(\([^()]*[+-][^()]*\))/g,
     '\\frac{$1}{$2}'
   )
 

--- a/src/utils/calculation/latexConverter.ts
+++ b/src/utils/calculation/latexConverter.ts
@@ -582,16 +582,14 @@ function convertFunctionNames(expression: string): string {
 
   // 2. 逆三角関数（度記号付き、複雑な場合は\left \right追加）
   result = replaceFunctionWithBalancedParens(result, 'asin', content => {
+    if (content.includes('\\frac{') && !content.includes('\\times')) {
+      return `\\sin^{-1}\\left(${content}\\right)°`
+    }
     return `\\sin^{-1}(${content})°`
   })
 
   result = replaceFunctionWithBalancedParens(result, 'acos', content => {
-    // 複雑な分数と平方根の組み合わせには\left \right追加
-    // 分数を含み、かつ平方根を含む場合、または複雑な関数呼び出しを含む場合
-    if (
-      content.includes('\\frac{') &&
-      (content.includes('\\sqrt{') || /\w+\([^)]*\)/.test(content))
-    ) {
+    if (content.includes('\\frac{') && !content.includes('\\times')) {
       return `\\cos^{-1}\\left(${content}\\right)°`
     }
     return `\\cos^{-1}(${content})°`

--- a/tests/unit/utils/latexConverter.test.ts
+++ b/tests/unit/utils/latexConverter.test.ts
@@ -482,4 +482,22 @@ describe('latexConverter', () => {
       )
     })
   })
+
+  describe('Issue #104 追加ケース', () => {
+    it('一般的な 1/(a+b) 形式を分数化する', () => {
+      expect(convertToLatexWithFunctionNames('1/(2+3+4)')).toBe(
+        '\\frac{1}{(2+3+4)}'
+      )
+    })
+
+    it('べき乗連鎖を右結合で変換する', () => {
+      expect(convertToLatexWithFunctionNames('2^3^4')).toBe('2^{3^{4}}')
+    })
+
+    it('atan の分数引数で left/right を一貫して付与する', () => {
+      expect(convertToLatexWithFunctionNames('atan((1+2)/(3+4))')).toBe(
+        '\\tan^{-1}\\left(\\frac{1+2}{3+4}\\right)°'
+      )
+    })
+  })
 })

--- a/tests/unit/utils/latexConverter.test.ts
+++ b/tests/unit/utils/latexConverter.test.ts
@@ -506,6 +506,21 @@ describe('latexConverter', () => {
       )
     })
 
+    it('asin/acos も分数引数の left/right 条件を atan と揃える', () => {
+      expect(convertToLatexWithFunctionNames('asin(1/(2+3))')).toBe(
+        '\\sin^{-1}\\left(\\frac{1}{(2+3)}\\right)°'
+      )
+      expect(convertToLatexWithFunctionNames('acos(1/(2+3))')).toBe(
+        '\\cos^{-1}\\left(\\frac{1}{(2+3)}\\right)°'
+      )
+      expect(convertToLatexWithFunctionNames('asin(1/(2+3)*4)')).toBe(
+        '\\sin^{-1}(\\frac{1}{(2+3)}\\times 4)°'
+      )
+      expect(convertToLatexWithFunctionNames('acos(1/(2+3)*4)')).toBe(
+        '\\cos^{-1}(\\frac{1}{(2+3)}\\times 4)°'
+      )
+    })
+
     it('指数内の LaTeX コマンドを atomic として扱う', () => {
       expect(convertToLatexWithFunctionNames('2^pi()')).toBe('2^{\\pi}')
     })

--- a/tests/unit/utils/latexConverter.test.ts
+++ b/tests/unit/utils/latexConverter.test.ts
@@ -499,5 +499,15 @@ describe('latexConverter', () => {
         '\\tan^{-1}\\left(\\frac{1+2}{3+4}\\right)°'
       )
     })
+
+    it('構造化パーサ経由でも atan の left/right 条件が一致する', () => {
+      expect(convertToLatexWithFunctionNames('atan(1/2*3)^2/3')).toBe(
+        '\\frac{\\tan^{-1}(\\frac{1}{2}\\times 3)°^{2}}{3}'
+      )
+    })
+
+    it('指数内の LaTeX コマンドを atomic として扱う', () => {
+      expect(convertToLatexWithFunctionNames('2^pi()')).toBe('2^{\\pi}')
+    })
   })
 })


### PR DESCRIPTION
### Motivation
- LaTeX変換で `1/(a+b)` のような一般的な分数形式が分数化されない問題を修正するため。 
- べき乗連鎖（例: `2^3^4`）が正しく右結合として表現されず見た目が誤解を招くため。 
- `atan` の分数引数に対する `\left ... \right` の付与条件が経路によって不統一で表示品質が揺れるため。

### Description
- `src/utils/calculation/latexConverter.ts` の `convertPowers` を再帰的に解析する実装に置き換え、連鎖べき乗を右結合として `2^{3^{4}}` 形式で変換するようにしました（`convertPowers` を再実装）。
- 分数変換ロジックに「項 / (加減算を含む括弧式)」の正規表現パターンを追加して、`1/(2+3+4)` のような取りこぼしを解消しました（`convertBasicFractions` 内のパターン追加）。
- 上記変更に対応するユニットテストを `tests/unit/utils/latexConverter.test.ts` に追加して再現ケースを検証しました（`1/(2+3+4)`、`2^3^4`、`atan((1+2)/(3+4))`）。
- 変更対象ファイルは `src/utils/calculation/latexConverter.ts` と `tests/unit/utils/latexConverter.test.ts` です（Issue #104 に対応、Close #104）。

### Testing
- `npm run test:unit tests/unit/utils/latexConverter.test.ts` を実行して追加ケースを含むユニットテストが全てグリーンであることを確認しました（成功）。
- プロジェクト全体の `npm run test`（unit + e2e）を実行して全テストが通ることを確認しました（成功）。
- `npm run lint`、`npm run format`、`npm run build` を実行し、それぞれ問題なく完了していることを確認しました（`build` はチャンクサイズの警告が出ますがビルド自体は成功）。
- 最終的に `npm run check` を実行し型チェック・lint・format・テストがすべてパスすることを確認しました（成功）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d617fda788331847fec89fe0f7419)

Close #104 