### PR TITLE
feat/step7-1: プリセットデータの自動ロードを実装

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,7 +94,8 @@ pocket-calcsheet_cca/
 │   │   │   └── variableValidation.ts # 変数名バリデーション
 │   │   └── storage/                  # ストレージ関連ユーティリティ
 │   │       ├── storageManager.ts     # localStorage抽象化レイヤー
-│   │       └── migrationManager.ts   # スキーママイグレーション
+│   │       ├── migrationManager.ts   # スキーママイグレーション
+│   │       └── presetData.ts         # プリセットデータ定義（sample1〜5）
 │   ├── lib/
 │   │   └── utils.ts                  # cnユーティリティ関数
 │   ├── types/
@@ -124,7 +125,8 @@ pocket-calcsheet_cca/
 │   │   │   └── mathEngine.test.ts    # 計算エンジンユニットテスト
 │   │   └── store/
 │   │       ├── sheetsStore.test.ts   # シートストアテスト
-│   │       └── storageManager.test.ts # StorageManager + MigrationManagerテスト
+│   │       ├── storageManager.test.ts # StorageManager + MigrationManagerテスト
+│   │       └── presetData.test.ts     # プリセットデータ構造テスト
 │   └── e2e/
 │       ├── app.spec.ts               # 基本動作E2Eテスト
 │       └── pwa.spec.ts               # PWA機能テスト

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,7 +99,8 @@ pocket-calcsheet_cca/
 │   │   │   └── variableValidation.ts # 変数名バリデーション
 │   │   └── storage/                  # ストレージ関連ユーティリティ
 │   │       ├── storageManager.ts     # localStorage抽象化レイヤー
-│   │       └── migrationManager.ts   # スキーママイグレーション
+│   │       ├── migrationManager.ts   # スキーママイグレーション
+│   │       └── presetData.ts         # プリセットデータ定義（sample1〜5）
 │   ├── lib/
 │   │   └── utils.ts                  # cnユーティリティ関数
 │   ├── types/
@@ -131,7 +132,8 @@ pocket-calcsheet_cca/
 │   │   │   └── latexConverter.test.ts # LaTeX変換ユニットテスト
 │   │   └── store/
 │   │       ├── sheetsStore.test.ts   # シートストアテスト
-│   │       └── storageManager.test.ts # StorageManager + MigrationManagerテスト
+│   │       ├── storageManager.test.ts # StorageManager + MigrationManagerテスト
+│   │       └── presetData.test.ts     # プリセットデータ構造テスト
 │   └── e2e/
 │       ├── app.spec.ts               # 基本動作E2Eテスト
 │       └── pwa.spec.ts               # PWA機能テスト

--- a/docs/design_others.md
+++ b/docs/design_others.md
@@ -90,19 +90,23 @@
   - `\frac{e^{[var_a]} - e^{-[var_a]}}{e^{[var_a]} + e^{-[var_a]}} + \tan(\sin^{-1}([var_b])°)` ※`°`が重複した場合は1つ削除
 
 # プリセットデータ
+
 - 初回起動時にプリセットデータをロードする。
 - ユーザーがトップページの編集でリストを全て削除した場合にプリセットデータを再度ロードする。
 
 ### sample1
+
 - 要素名: "sample1"
 - Overviewタブ(Formula,Resultは自動計算し表示)
   - Overview
+
 ```
 自由落下の落下時間から落下距離を算出する。
 g:重力加速度[m/s^2]
 t:落下時間[sec]
 result:落下距離[m]
 ```
+
 - Variablesタブ(Resultは自動計算し表示)
   - Variable1
     - name: "g"
@@ -112,10 +116,13 @@ result:落下距離[m]
     - value: "5"
 - Formulaタブ(Resultは自動計算し表示)
   - Formula: "1/2*[g]*[t]^2"
+
 ### sample2
+
 - 要素名: "sample2"
 - Overviewタブ(Formula,Resultは自動計算し表示)
   - Overview
+
 ```
 標高と気温から気圧を算出する。
 h:標高[m]
@@ -123,6 +130,7 @@ T:気温[℃]
 P0:海面気圧[hPa]
 result:気圧[hPa]
 ```
+
 - Variablesタブ(Resultは自動計算し表示)
   - Variable1
     - name: "h"
@@ -134,17 +142,21 @@ result:気圧[hPa]
     - name: "P0"
     - value: "1013.25"
 - Formulaタブ(Resultは自動計算し表示)
-  - Formula: "[P0]*(1-((0.0065*[h])/([T]+0.0065*[h]+273.15)))^5.257"
+  - Formula: "[P0]_(1-((0.0065_[h])/([T]+0.0065\*[h]+273.15)))^5.257"
+
 ### sample3
+
 - 要素名: "sample3"
 - Overviewタブ(Formula,Resultは自動計算し表示)
   - Overview
+
 ```
 二等辺三角形の底辺と高さから底角を算出する。
 h:高さ
 a:底辺の長さ
 result:底角[°]
 ```
+
 - Variablesタブ(Resultは自動計算し表示)
   - Variable1
     - name: "h"
@@ -153,30 +165,37 @@ result:底角[°]
     - name: "a"
     - value: "2"
 - Formulaタブ(Resultは自動計算し表示)
-  - Formula: "atan(2*[h]/[a])"
+  - Formula: "atan(2\*[h]/[a])"
+
 ### sample4
+
 - 要素名: "sample4"
 - Overviewタブ(Formula,Resultは自動計算し表示)
   - Overview
+
 ```
 インダクタとキャパシタの値からLCローパスフィルタのカットオフ周波数を算出。
 L:インダクタンス[H]
 C:キャパシタンス[F]
 result:カットオフ周波数[Hz]
 ```
+
 - Variablesタブ(Resultは自動計算し表示)
   - Variable1
     - name: "L"
-    - value: "1*10^(-6)"
+    - value: "1\*10^(-6)"
   - Variable2
     - name: "C"
-    - value: "12*10^(-12)"
+    - value: "12\*10^(-12)"
 - Formulaタブ(Resultは自動計算し表示)
-  - Formula: "1/(2*pi()*sqrt([L]*[C]))"
+  - Formula: "1/(2*pi()*sqrt([L]\*[C]))"
+
 ### sample5
+
 - 要素名: "sample5"
 - Overviewタブ(Formula,Resultは自動計算し表示)
   - Overview
+
 ```
 距離の変化から音圧の減衰量を算出する。
 pointA:音圧が既知である点の音源からの距離[m]
@@ -184,6 +203,7 @@ pointB:音圧を算出したい点の音源からの距離[m]
 volumeA:pointAの音圧[dB]
 result:pointBの音圧[dB]
 ```
+
 - Variablesタブ(Resultは自動計算し表示)
   - Variable1
     - name: "pointA"
@@ -195,4 +215,4 @@ result:pointBの音圧[dB]
     - name: "volumeA"
     - value: "100"
 - Formulaタブ(Resultは自動計算し表示)
-  - Formula: "[volumeA]-20*log([pointB]/[pointA])"
+  - Formula: "[volumeA]-20\*log([pointB]/[pointA])"

--- a/src/store/sheetsStore.ts
+++ b/src/store/sheetsStore.ts
@@ -11,6 +11,7 @@ import type {
 import type { RootModel, Sheet } from '@/types/storage'
 import { StorageManager } from '@/utils/storage/storageManager'
 import { MigrationManager } from '@/utils/storage/migrationManager'
+import { PRESET_SHEETS } from '@/utils/storage/presetData'
 
 interface SheetsStore extends RootModel {
   schemaVersion: number
@@ -39,6 +40,7 @@ interface SheetsStore extends RootModel {
     overviewData: Partial<OverviewData>
   ) => void
   initializeSheet: (sheetId: string) => void
+  loadPresets: () => void
   reset: () => void
 }
 
@@ -85,6 +87,7 @@ const getInitialState = (): Omit<
   | 'reset'
   | 'setStorageError'
   | 'setPersistenceError'
+  | 'loadPresets'
 > => ({
   schemaVersion: MigrationManager.LATEST_SCHEMA_VERSION,
   savedAt: new Date().toISOString(),
@@ -94,6 +97,27 @@ const getInitialState = (): Omit<
   persistenceError: false,
 })
 
+const createPresetState = () => {
+  const sheets = PRESET_SHEETS.map(
+    ({ id, name, order, createdAt, updatedAt }) => ({
+      id,
+      name,
+      order,
+      createdAt,
+      updatedAt,
+    })
+  )
+
+  const entities = Object.fromEntries(
+    PRESET_SHEETS.map(sheet => [sheet.id, sheet])
+  )
+
+  return {
+    sheets,
+    entities,
+    savedAt: new Date().toISOString(),
+  }
+}
 export const useSheetsStore = create<SheetsStore>()(
   persist(
     (set, get) => ({
@@ -145,12 +169,21 @@ export const useSheetsStore = create<SheetsStore>()(
           savedAt: new Date().toISOString(),
         }))
       },
+      loadPresets: () => {
+        set(createPresetState())
+      },
       removeSheet: (id: string) => {
         set(state => {
+          const remainingSheets = state.sheets.filter(sheet => sheet.id !== id)
           const remainingEntities = { ...state.entities }
           delete remainingEntities[id]
+
+          if (remainingSheets.length === 0) {
+            return createPresetState()
+          }
+
           return {
-            sheets: state.sheets.filter(sheet => sheet.id !== id),
+            sheets: remainingSheets,
             entities: remainingEntities,
             savedAt: new Date().toISOString(),
           }
@@ -386,10 +419,15 @@ export const useSheetsStore = create<SheetsStore>()(
         entities: state.entities,
         // storageErrorとpersistenceErrorは永続化しない
       }),
-      onRehydrateStorage: () => (_state, error) => {
+      onRehydrateStorage: () => (state, error) => {
         if (error) {
           console.error('Failed to rehydrate storage:', error)
           useSheetsStore.getState().setStorageError(true)
+          return
+        }
+
+        if (state && state.sheets.length === 0) {
+          state.loadPresets()
         }
       },
       migrate: (persistedState: unknown): RootModel => {

--- a/src/store/sheetsStore.ts
+++ b/src/store/sheetsStore.ts
@@ -109,7 +109,7 @@ const createPresetState = () => {
   )
 
   const entities = Object.fromEntries(
-    PRESET_SHEETS.map(sheet => [sheet.id, sheet])
+    PRESET_SHEETS.map(sheet => [sheet.id, structuredClone(sheet)])
   )
 
   return {

--- a/src/store/sheetsStore.ts
+++ b/src/store/sheetsStore.ts
@@ -12,6 +12,11 @@ import type { RootModel, Sheet } from '@/types/storage'
 import { StorageManager } from '@/utils/storage/storageManager'
 import { MigrationManager } from '@/utils/storage/migrationManager'
 import { PRESET_SHEETS } from '@/utils/storage/presetData'
+import {
+  evaluateExpression,
+  evaluateFormulaExpression,
+} from '@/utils/calculation/mathEngine'
+import type { CalculationContext } from '@/types/calculation'
 
 interface SheetsStore extends RootModel {
   schemaVersion: number
@@ -98,6 +103,58 @@ const getInitialState = (): Omit<
 })
 
 const createPresetState = () => {
+  const calculatePresetSheet = (sheet: Sheet): Sheet => {
+    const variables: Record<string, number | null> = {}
+    const variableSlots = sheet.variableSlots.map(slot => ({ ...slot }))
+
+    for (let iteration = 0; iteration < 2; iteration++) {
+      variableSlots.forEach((slot, index) => {
+        if (!slot.expression.trim()) {
+          variableSlots[index] = { ...slot, value: null, error: null }
+          if (slot.varName) {
+            variables[slot.varName] = null
+          }
+          return
+        }
+
+        const context: CalculationContext = {
+          variables,
+          variableSlots,
+        }
+
+        const result = evaluateExpression(slot.expression, context)
+
+        variableSlots[index] = {
+          ...slot,
+          value: result.value,
+          error: result.error,
+        }
+
+        if (slot.varName) {
+          variables[slot.varName] = result.value
+        }
+      })
+    }
+
+    const formulaResult = evaluateFormulaExpression(
+      sheet.formulaData.inputExpr,
+      {
+        variables,
+        variableSlots,
+      }
+    )
+
+    return {
+      ...sheet,
+      variableSlots,
+      formulaData: {
+        ...sheet.formulaData,
+        result: formulaResult.value,
+        error: formulaResult.error,
+      },
+    }
+  }
+
   const sheets = PRESET_SHEETS.map(
     ({ id, name, order, createdAt, updatedAt }) => ({
       id,
@@ -109,7 +166,10 @@ const createPresetState = () => {
   )
 
   const entities = Object.fromEntries(
-    PRESET_SHEETS.map(sheet => [sheet.id, structuredClone(sheet)])
+    PRESET_SHEETS.map(sheet => {
+      const clonedSheet = structuredClone(sheet)
+      return [sheet.id, calculatePresetSheet(clonedSheet)]
+    })
   )
 
   return {

--- a/src/utils/storage/presetData.ts
+++ b/src/utils/storage/presetData.ts
@@ -1,0 +1,107 @@
+import type { VariableSlot } from '@/types/sheet'
+import type { Sheet } from '@/types/storage'
+
+const PRESET_TIMESTAMP = '2026-01-01T00:00:00.000Z'
+
+const createEmptySlots = (): VariableSlot[] =>
+  Array.from({ length: 8 }, (_, index) => ({
+    slot: index + 1,
+    varName: '',
+    expression: '',
+    value: null,
+    error: null,
+  }))
+
+const createPresetSheet = (
+  id: string,
+  name: string,
+  order: number,
+  description: string,
+  variables: Array<{ slot: number; varName: string; expression: string }>,
+  formula: string
+): Sheet => {
+  const variableSlots = createEmptySlots()
+
+  variables.forEach(variable => {
+    variableSlots[variable.slot - 1] = {
+      ...variableSlots[variable.slot - 1],
+      varName: variable.varName,
+      expression: variable.expression,
+    }
+  })
+
+  return {
+    id,
+    name,
+    order,
+    createdAt: PRESET_TIMESTAMP,
+    updatedAt: PRESET_TIMESTAMP,
+    overviewData: { description },
+    variableSlots,
+    formulaData: {
+      inputExpr: formula,
+      result: null,
+      error: null,
+    },
+  }
+}
+
+export const PRESET_SHEETS: Sheet[] = [
+  createPresetSheet(
+    '11111111-1111-4111-8111-111111111111',
+    'sample1',
+    0,
+    '自由落下の落下時間から落下距離を算出する。\ng:重力加速度[m/s^2]\nt:落下時間[sec]\nresult:落下距離[m]',
+    [
+      { slot: 1, varName: 'g', expression: '9.80665' },
+      { slot: 2, varName: 't', expression: '5' },
+    ],
+    '1/2*[g]*[t]^2'
+  ),
+  createPresetSheet(
+    '22222222-2222-4222-8222-222222222222',
+    'sample2',
+    1,
+    '標高と気温から気圧を算出する。\nh:標高[m]\nT:気温[℃]\nP0:海面気圧[hPa]\nresult:気圧[hPa]',
+    [
+      { slot: 1, varName: 'h', expression: '1000' },
+      { slot: 2, varName: 'T', expression: '5' },
+      { slot: 3, varName: 'P0', expression: '1013.25' },
+    ],
+    '[P0]*(1-((0.0065*[h])/([T]+0.0065*[h]+273.15)))^5.257'
+  ),
+  createPresetSheet(
+    '33333333-3333-4333-8333-333333333333',
+    'sample3',
+    2,
+    '二等辺三角形の底辺と高さから底角を算出する。\nh:高さ\na:底辺の長さ\nresult:底角[°]',
+    [
+      { slot: 1, varName: 'h', expression: '1' },
+      { slot: 2, varName: 'a', expression: '2' },
+    ],
+    'atan(2*[h]/[a])'
+  ),
+  createPresetSheet(
+    '44444444-4444-4444-8444-444444444444',
+    'sample4',
+    3,
+    'インダクタとキャパシタの値からLCローパスフィルタのカットオフ周波数を算出。\nL:インダクタンス[H]\nC:キャパシタンス[F]\nresult:カットオフ周波数[Hz]',
+    [
+      { slot: 1, varName: 'L', expression: '1*10^(-6)' },
+      { slot: 2, varName: 'C', expression: '12*10^(-12)' },
+    ],
+    '1/(2*pi()*sqrt([L]*[C]))'
+  ),
+  createPresetSheet(
+    '55555555-5555-4555-8555-555555555555',
+    'sample5',
+    4,
+    '距離の変化から音圧の減衰量を算出する。\npointA:音圧が既知である点の音源からの距離[m]\npointB:音圧を算出したい点の音源からの距離[m]\nvolumeA:pointAの音圧[dB]\nresult:pointBの音圧[dB]',
+    [
+      { slot: 1, varName: 'pointA', expression: '1' },
+      { slot: 2, varName: 'pointB', expression: '10' },
+      { slot: 3, varName: 'volumeA', expression: '100' },
+    ],
+    '[volumeA]-20*log([pointB]/[pointA])'
+  ),
+]

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -104,7 +104,7 @@ test.describe('アプリケーション基本動作確認', () => {
     await expect(page.locator('text=編集後の名前')).toBeVisible()
 
     // 3. 削除実行
-    await page.locator('[data-testid="delete-button"]').click()
+    await page.getByRole('button', { name: '編集後の名前を削除' }).click()
     await page.locator('button:has-text("削除")').click()
     await expect(page.locator('text=編集後の名前')).not.toBeVisible()
   })
@@ -120,7 +120,7 @@ test.describe('アプリケーション基本動作確認', () => {
     await input.press('Enter')
 
     // 削除ダイアログ表示確認
-    await page.locator('[data-testid="delete-button"]').click()
+    await page.getByRole('button', { name: '削除テストシートを削除' }).click()
     const alertDialog = page.locator('[role="alertdialog"]')
     await expect(alertDialog).toBeVisible()
     await expect(

--- a/tests/unit/components/App.test.tsx
+++ b/tests/unit/components/App.test.tsx
@@ -5,6 +5,7 @@ import { TopPage } from '../../../src/pages/TopPage'
 import { StorageManager } from '../../../src/utils/storage/storageManager'
 import { useUIStore } from '../../../src/store/uiStore'
 import { useSheetsStore } from '../../../src/store/sheetsStore'
+import { MemoryRouter } from 'react-router-dom'
 
 // テスト用のRouter wrapper - App.tsxには既にHashRouterがあるので包む必要なし
 const renderWithRouter = (
@@ -109,22 +110,44 @@ describe('App - Step2-1対応後のテスト', () => {
 })
 
 describe('TopPage', () => {
+  let consoleWarnSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    consoleWarnSpy.mockRestore()
+  })
+
   test('正常にレンダリングされる', () => {
-    render(<TopPage />)
+    render(
+      <MemoryRouter>
+        <TopPage />
+      </MemoryRouter>
+    )
 
     const topPage = screen.getByTestId('top-page')
     expect(topPage).toBeInTheDocument()
   })
 
   test('アプリ名「ぽけっと計算表」が表示される', () => {
-    render(<TopPage />)
+    render(
+      <MemoryRouter>
+        <TopPage />
+      </MemoryRouter>
+    )
 
     const appName = screen.getByText('ぽけっと計算表')
     expect(appName).toBeInTheDocument()
   })
 
   test('編集ボタンが存在する', () => {
-    render(<TopPage />)
+    render(
+      <MemoryRouter>
+        <TopPage />
+      </MemoryRouter>
+    )
 
     const editButton = screen.getByTestId('edit-button')
     expect(editButton).toBeInTheDocument()
@@ -132,7 +155,11 @@ describe('TopPage', () => {
   })
 
   test('SheetListコンポーネントが表示される', () => {
-    render(<TopPage />)
+    render(
+      <MemoryRouter>
+        <TopPage />
+      </MemoryRouter>
+    )
 
     const sheetList = screen.getByTestId('sheet-list')
     expect(sheetList).toBeInTheDocument()

--- a/tests/unit/store/presetData.test.ts
+++ b/tests/unit/store/presetData.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { PRESET_SHEETS } from '@/utils/storage/presetData'
+
+describe('presetData', () => {
+  it('sample1〜5 が5件定義されている', () => {
+    expect(PRESET_SHEETS).toHaveLength(5)
+  })
+
+  it('各プリセットが必須フィールドを持つ', () => {
+    PRESET_SHEETS.forEach(sheet => {
+      expect(sheet.id).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+      )
+      expect(sheet.name).toBeTruthy()
+      expect(sheet.variableSlots).toHaveLength(8)
+      expect(sheet.formulaData).toBeDefined()
+      expect(sheet.overviewData).toBeDefined()
+    })
+  })
+
+  it('variableSlots の slot 番号が 1〜8 の連番である', () => {
+    PRESET_SHEETS.forEach(sheet => {
+      expect(sheet.variableSlots.map(slot => slot.slot)).toEqual([
+        1, 2, 3, 4, 5, 6, 7, 8,
+      ])
+    })
+  })
+})

--- a/tests/unit/store/sheetsStore.test.ts
+++ b/tests/unit/store/sheetsStore.test.ts
@@ -96,6 +96,19 @@ describe('SheetsStore', () => {
       expect(Object.keys(entities)).toHaveLength(5)
     })
 
+    it('loadPresetsでプリセットのVariablesとFormula結果が計算済みになる', () => {
+      const { loadPresets } = useSheetsStore.getState()
+      loadPresets()
+
+      const state = useSheetsStore.getState()
+      const sample1 = state.entities[state.sheets[0].id]
+
+      expect(sample1.variableSlots[0].value).not.toBeNull()
+      expect(sample1.variableSlots[1].value).not.toBeNull()
+      expect(sample1.formulaData.result).not.toBeNull()
+      expect(sample1.formulaData.error).toBeNull()
+    })
+
     it('loadPresets後にsheetsとentitiesのキーが一致する', () => {
       const { loadPresets } = useSheetsStore.getState()
       loadPresets()

--- a/tests/unit/store/sheetsStore.test.ts
+++ b/tests/unit/store/sheetsStore.test.ts
@@ -39,7 +39,7 @@ describe('SheetsStore', () => {
       removeSheet(sheetId)
 
       const { sheets, entities } = useSheetsStore.getState()
-      expect(sheets).toHaveLength(0)
+      expect(sheets).toHaveLength(5)
       expect(entities[sheetId]).toBeUndefined()
     })
 
@@ -82,6 +82,45 @@ describe('SheetsStore', () => {
     })
   })
 
+  describe('プリセットデータ', () => {
+    beforeEach(() => {
+      useSheetsStore.getState().reset?.()
+    })
+
+    it('loadPresetsで5件ロードされる', () => {
+      const { loadPresets } = useSheetsStore.getState()
+      loadPresets()
+
+      const { sheets, entities } = useSheetsStore.getState()
+      expect(sheets).toHaveLength(5)
+      expect(Object.keys(entities)).toHaveLength(5)
+    })
+
+    it('loadPresets後にsheetsとentitiesのキーが一致する', () => {
+      const { loadPresets } = useSheetsStore.getState()
+      loadPresets()
+
+      const { sheets, entities } = useSheetsStore.getState()
+      sheets.forEach(sheet => {
+        expect(entities[sheet.id]).toBeDefined()
+      })
+    })
+
+    it('最後の1件削除でプリセットが再ロードされる', () => {
+      const { loadPresets, removeSheet } = useSheetsStore.getState()
+      loadPresets()
+
+      useSheetsStore
+        .getState()
+        .sheets.slice(0, 4)
+        .forEach(sheet => removeSheet(sheet.id))
+
+      const lastSheet = useSheetsStore.getState().sheets[0]
+      removeSheet(lastSheet.id)
+
+      expect(useSheetsStore.getState().sheets).toHaveLength(5)
+    })
+  })
   describe('初期状態', () => {
     it('初期状態では空の配列を持つ', () => {
       const state = useSheetsStore.getState()
@@ -568,7 +607,7 @@ describe('SheetsStore', () => {
       expect(unchangedSheets[2].name).toBe('シート3')
     })
 
-    it('すべてのシートを削除して空にできる', () => {
+    it('すべてのシートを削除するとプリセットが再ロードされる', () => {
       const { removeSheet } = useSheetsStore.getState()
       const initialSheets = useSheetsStore.getState().sheets
 
@@ -578,7 +617,7 @@ describe('SheetsStore', () => {
       })
 
       const emptySheets = useSheetsStore.getState().sheets
-      expect(emptySheets).toHaveLength(0)
+      expect(emptySheets).toHaveLength(5)
     })
 
     it('削除処理が配列の整合性を保つ', () => {

--- a/tests/unit/store/sheetsStore.test.ts
+++ b/tests/unit/store/sheetsStore.test.ts
@@ -937,8 +937,8 @@ describe('SheetsStore', () => {
       // フォールバック後のデータを確認
       const state = useSheetsStore.getState()
       expect(state.schemaVersion).toBe(1)
-      expect(state.sheets).toEqual([])
-      expect(state.entities).toEqual({})
+      expect(state.sheets).toHaveLength(5)
+      expect(Object.keys(state.entities)).toHaveLength(5)
       expect(state.savedAt).toMatch(
         /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/
       )
@@ -961,8 +961,8 @@ describe('SheetsStore', () => {
       // 初期状態が設定されることを確認
       const state = useSheetsStore.getState()
       expect(state.schemaVersion).toBe(1)
-      expect(state.sheets).toEqual([])
-      expect(state.entities).toEqual({})
+      expect(state.sheets).toHaveLength(5)
+      expect(Object.keys(state.entities)).toHaveLength(5)
       expect(state.savedAt).toMatch(
         /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/
       )
@@ -985,9 +985,11 @@ describe('SheetsStore', () => {
       // デフォルト値が設定されることを確認
       const state = useSheetsStore.getState()
       expect(state.schemaVersion).toBe(1)
-      expect(state.savedAt).toBe('2023-01-01T00:00:00.000Z')
-      expect(state.sheets).toEqual([])
-      expect(state.entities).toEqual({})
+      expect(state.savedAt).toMatch(
+        /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/
+      )
+      expect(state.sheets).toHaveLength(5)
+      expect(Object.keys(state.entities)).toHaveLength(5)
     })
 
     it('複数のシートを含む旧データのマイグレーション', async () => {

--- a/tests/unit/store/sheetsStore.test.ts
+++ b/tests/unit/store/sheetsStore.test.ts
@@ -106,6 +106,23 @@ describe('SheetsStore', () => {
       })
     })
 
+    it('プリセットを編集しても再ロード時に初期値が維持される', () => {
+      const { loadPresets, updateOverviewData, removeSheet } =
+        useSheetsStore.getState()
+      loadPresets()
+
+      const firstSheetId = useSheetsStore.getState().sheets[0].id
+      updateOverviewData(firstSheetId, { description: '編集済み' })
+
+      useSheetsStore.getState().sheets.forEach(sheet => removeSheet(sheet.id))
+
+      const reloadedFirstSheetId = useSheetsStore.getState().sheets[0].id
+      expect(
+        useSheetsStore.getState().entities[reloadedFirstSheetId].overviewData
+          .description
+      ).toContain('自由落下の落下時間から落下距離を算出する。')
+    })
+
     it('最後の1件削除でプリセットが再ロードされる', () => {
       const { loadPresets, removeSheet } = useSheetsStore.getState()
       loadPresets()


### PR DESCRIPTION
### Motivation
- 初回起動およびユーザーがトップページで全シートを削除した際に、sample1〜sample5 のプリセットを自動的にロードして初期状態を提供するため。

### Description
- `src/utils/storage/presetData.ts` を追加し、sample1〜5 を固定UUID付きで Overview / VariableSlots(1〜8) / FormulaData を含む形で定義した。 
- `src/store/sheetsStore.ts` に `loadPresets` アクションを追加し、`removeSheet` 実行時に全件削除が発生した場合はプリセットを再ロードするロジックを組み込んだ。 
- persist の `onRehydrateStorage` フックを拡張し、ストレージ復元後に `sheets` が空なら `loadPresets` を実行するようにした（初回起動対応）。
- ユニットテスト `tests/unit/store/presetData.test.ts` を新規追加しプリセット構造を検証し、`tests/unit/store/sheetsStore.test.ts` にプリセットのロード／再ロードに関するテストを追加した。 
- ドキュメント（`AGENTS.md`, `CLAUDE.md`）のディレクトリ構成に `presetData.ts` と `presetData.test.ts` の記載を追加した。 

### Testing
- `npm run test:unit tests/unit/store/presetData.test.ts tests/unit/store/sheetsStore.test.ts` を実行し該当ユニットテストは成功（ローカル確認）。
- プロジェクト全体のチェックで以下を実行し成功した：`npm run format`（Prettier適用）、`npm run check`（型チェック/lin/format/テスト）、および `npm run build`（ビルド成功）。
- 追加検証としてプロジェクト全ユニットテストとE2Eを実行し全テストがパスしたことを確認（Vitest 全ユニットテスト成功、Playwright E2E 全48件成功）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1532bceebc8331978ae3008853b949)
close #109 