### PR TITLE
FormulaタブにLaTeX式表示を追加

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,8 @@ pocket-calcsheet_cca/
 │   │   ├── calculator/               # 計算機能コンポーネント
 │   │   │   ├── VariableSlot.tsx      # 変数スロット(名前+式+値)
 │   │   │   ├── FormulaInput.tsx      # 数式入力コンポーネント
-│   │   │   └── ResultDisplay.tsx     # 計算結果表示
+│   │   │   ├── ResultDisplay.tsx     # 計算結果表示
+│   │   │   └── ExpressionRenderer.tsx # Formula/Overview用LaTeX式表示
 │   │   ├── keyboard/                 # カスタムキーボード関連コンポーネント
 │   │   │   ├── CustomKeyboard.tsx    # カスタムキーボード本体
 │   │   │   ├── FunctionPicker.tsx    # 関数選択ドラムロールUI
@@ -117,12 +118,14 @@ pocket-calcsheet_cca/
 │   │   │   ├── TabNavigation.test.tsx # タブナビゲーション関連テスト
 │   │   │   ├── VariableSlot.test.tsx # 変数スロットテスト
 │   │   │   ├── CustomKeyboard.test.tsx # カスタムキーボードテスト
-│   │   │   └── ResultDisplay.test.tsx # 計算結果表示テスト
+│   │   │   ├── ResultDisplay.test.tsx # 計算結果表示テスト
+│   │   │   └── ExpressionRenderer.test.tsx # LaTeX式表示テスト
 │   │   ├── hooks/
 │   │   │   └── useScrollToInput.test.ts # スクロール制御フックテスト
 │   │   ├── utils/
 │   │   │   ├── validation.test.ts    # バリデーションテスト
-│   │   │   └── mathEngine.test.ts    # 計算エンジンユニットテスト
+│   │   │   ├── mathEngine.test.ts    # 計算エンジンユニットテスト
+│   │   │   └── latexConverter.test.ts # LaTeX変換ユニットテスト
 │   │   └── store/
 │   │       ├── sheetsStore.test.ts   # シートストアテスト
 │   │       ├── storageManager.test.ts # StorageManager + MigrationManagerテスト
@@ -297,7 +300,7 @@ npm run preview       # ビルド後のプレビュー
 - **pages/**: 各画面のルートコンポーネント (Top, Overview, Variables, Formula タブ)
 - **components/sheets/**: シート一覧・編集機能
 - **components/keyboard/**: カスタムキーボード実装 (ネイティブキーボード無効)
-- **components/calculator/**: 変数スロット・数式入力・結果表示
+- **components/calculator/**: 変数スロット・数式入力・LaTeX式表示・結果表示
 - **utils/calculation/**: 数式パース・LaTeX変換・数値フォーマット
 
 ### Mobile-First Design
@@ -317,7 +320,7 @@ npm run preview       # ビルド後のプレビュー
 - **変数参照**: `[var1]` 形式での相互参照
 - **循環参照対応**: 2回再計算で打ち切り
 - **SI接頭語表示**: 10の3の倍数乗での数値表示
-- **LaTeX変換**: 関数名変換 (atan → tan^{-1}) とカスタムTeX生成
+- **LaTeX変換**: 関数名変換 (atan → tan^{-1}) とカスタムTeX生成。OverviewタブとFormulaタブで同じ`ExpressionRenderer`を使用
 
 ## Development Guidelines
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -272,7 +272,7 @@ npm run preview       # ビルド後のプレビュー
 - **pages/**: 各画面のルートコンポーネント (Top, Overview, Variables, Formula タブ)
 - **components/sheets/**: シート一覧・編集機能
 - **components/keyboard/**: カスタムキーボード実装 (ネイティブキーボード無効)
-- **components/calculator/**: 変数スロット・数式入力・結果表示
+- **components/calculator/**: 変数スロット・数式入力・LaTeX式表示・結果表示
 - **utils/calculation/**: 数式パース・LaTeX変換・数値フォーマット
 
 ### Mobile-First Design
@@ -292,7 +292,7 @@ npm run preview       # ビルド後のプレビュー
 - **変数参照**: `[var1]` 形式での相互参照
 - **循環参照対応**: 2回再計算で打ち切り
 - **SI接頭語表示**: 10の3の倍数乗での数値表示
-- **LaTeX変換**: 関数名変換 (atan → tan^{-1}) とカスタムTeX生成
+- **LaTeX変換**: 関数名変換 (atan → tan^{-1}) とカスタムTeX生成。OverviewタブとFormulaタブで同じ`ExpressionRenderer`を使用
 
 ## Development Guidelines
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -155,7 +155,11 @@ https://2dice.tech/category/ios-app/calcsheet/
     - 数式の保存/読み出し(localStorage)
       - タブ表示時に読み出し、入力完了時に保存
       - 状態管理ライブラリのストア内でlocalStorageへの保存・読み込み処理をカプセル化
-  - "Result"ラベルの下に計算結果を表示(テキストボックスの下。結果は右詰)(step5-2)
+  - Formula入力欄とResult表示の間に、Formulaタブで入力した数式のLaTeX表示を配置
+    - 表示内容はoverviewタブのFormula表示(step6-2)と同じ
+    - Formula欄の入力完了時に保存された数式をもとに表示し、Resultの再計算と同じ状態更新に追従する
+    - 入力式が空の場合はLaTeX表示エリアを表示しない
+  - "Result"ラベルの下に計算結果を表示(LaTeX表示の下。結果は右詰)(step5-2)
     - 計算結果の表示ルールはvariablesタブの計算値と同様
       - ただし小数点以下の表示桁数だけは15桁まで表示する
     - variablesタブの変数は計算後のラベルでは無く計算式の計算結果を使用(ラベルは値を丸めているため)
@@ -173,6 +177,7 @@ https://2dice.tech/category/ios-app/calcsheet/
       - タブ表示時に読み出し、入力完了時に保存
   - Formula表示(step6-2)
     - Formulaラベルをoverviewテキストボックス左下に配置
+    - Formulaタブ内にも同じ表示をFormula入力欄とResult表示の間に配置
     - 1行目にFormulaタブで入力した数式をそのまま記述(改行含む)
     - 2行目に関数名以外の数式をKaTeXで自然な数式に変換した式を記述(改行削除、LaTeX)
       - 例:atan関数はatan表記のまま。tan^{-1}の形式に変換しない

--- a/docs/design_directory_data.md
+++ b/docs/design_directory_data.md
@@ -106,7 +106,8 @@ pocket-calcsheet_cca/
 │   │   │   ├── CustomKeyboard.test.tsx # カスタムキーボードテスト
 │   │   │   ├── FormulaInput.test.tsx   # 数式入力コンポーネントテスト
 │   │   │   ├── VariableSlot.test.tsx   # 変数スロットテスト
-│   │   │   └── ResultDisplay.test.tsx  # 計算結果表示テスト
+│   │   │   ├── ResultDisplay.test.tsx  # 計算結果表示テスト
+│   │   │   └── ExpressionRenderer.test.tsx # LaTeX式表示テスト
 │   │   ├── utils/
 │   │   │   ├── mathEngine.test.ts     # 計算エンジンユニットテスト
 │   │   │   ├── latexConverter.test.ts # LaTeX変換テスト

--- a/docs/design_others.md
+++ b/docs/design_others.md
@@ -114,7 +114,7 @@ result:落下距離[m]
   - Variable2
     - name: "t"
     - value: "5"
-- Formulaタブ(Resultは自動計算し表示)
+- Formulaタブ(FormulaのLaTeX表示とResultは自動計算し表示)
   - Formula: "1/2*[g]*[t]^2"
 
 ### sample2
@@ -141,7 +141,7 @@ result:気圧[hPa]
   - Variable3
     - name: "P0"
     - value: "1013.25"
-- Formulaタブ(Resultは自動計算し表示)
+- Formulaタブ(FormulaのLaTeX表示とResultは自動計算し表示)
   - Formula: "[P0]_(1-((0.0065_[h])/([T]+0.0065\*[h]+273.15)))^5.257"
 
 ### sample3
@@ -164,7 +164,7 @@ result:底角[°]
   - Variable2
     - name: "a"
     - value: "2"
-- Formulaタブ(Resultは自動計算し表示)
+- Formulaタブ(FormulaのLaTeX表示とResultは自動計算し表示)
   - Formula: "atan(2\*[h]/[a])"
 
 ### sample4
@@ -187,7 +187,7 @@ result:カットオフ周波数[Hz]
   - Variable2
     - name: "C"
     - value: "12\*10^(-12)"
-- Formulaタブ(Resultは自動計算し表示)
+- Formulaタブ(FormulaのLaTeX表示とResultは自動計算し表示)
   - Formula: "1/(2*pi()*sqrt([L]\*[C]))"
 
 ### sample5
@@ -214,5 +214,5 @@ result:pointBの音圧[dB]
   - Variable3
     - name: "volumeA"
     - value: "100"
-- Formulaタブ(Resultは自動計算し表示)
+- Formulaタブ(FormulaのLaTeX表示とResultは自動計算し表示)
   - Formula: "[volumeA]-20\*log([pointB]/[pointA])"

--- a/src/pages/FormulaTab.tsx
+++ b/src/pages/FormulaTab.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo } from 'react'
 import { useParams } from 'react-router-dom'
 import { FormulaInput } from '@/components/calculator/FormulaInput'
+import { ExpressionRenderer } from '@/components/calculator/ExpressionRenderer'
 import { ResultDisplay } from '@/components/calculator/ResultDisplay'
 import { CustomKeyboard } from '@/components/keyboard/CustomKeyboard'
 import { useSheetsStore } from '@/store'
@@ -87,6 +88,15 @@ export function FormulaTab() {
         }}
       >
         <FormulaInput value={sheet.formulaData.inputExpr} />
+
+        {sheet.formulaData.inputExpr && (
+          <div
+            data-testid="formula-display"
+            className="mt-6 p-3 bg-gray-50 rounded-md border"
+          >
+            <ExpressionRenderer expression={sheet.formulaData.inputExpr} />
+          </div>
+        )}
 
         <ResultDisplay
           result={sheet.formulaData.result}

--- a/tests/unit/components/App.test.tsx
+++ b/tests/unit/components/App.test.tsx
@@ -421,3 +421,75 @@ describe('Navigation Components - React Router対応', () => {
     })
   })
 })
+
+describe('FormulaTab - LaTeX式表示', () => {
+  let mockRequestPersistentStorage: ReturnType<typeof vi.spyOn>
+  let consoleWarnSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    mockRequestPersistentStorage = vi
+      .spyOn(StorageManager, 'requestPersistentStorage')
+      .mockResolvedValue(true)
+
+    act(() => {
+      useSheetsStore.setState({
+        schemaVersion: 1,
+        savedAt: new Date().toISOString(),
+        sheets: [],
+        entities: {},
+        storageError: false,
+        persistenceError: false,
+      })
+      useUIStore.setState({
+        isEditMode: false,
+        keyboardState: { visible: false, target: null },
+        keyboardInput: null,
+      })
+      useSheetsStore.getState().addSheet('数式表示テスト')
+      const sheet = useSheetsStore.getState().sheets[0]
+      useSheetsStore
+        .getState()
+        .updateFormulaData(sheet.id, { inputExpr: 'atan(2*[var1]/[var2])' })
+    })
+  })
+
+  afterEach(() => {
+    mockRequestPersistentStorage.mockRestore()
+    consoleWarnSpy.mockRestore()
+    act(() => {
+      useSheetsStore.setState({
+        schemaVersion: 1,
+        savedAt: new Date().toISOString(),
+        sheets: [],
+        entities: {},
+        storageError: false,
+        persistenceError: false,
+      })
+    })
+  })
+
+  test('Formula入力欄とResultの間にOverviewと同じLaTeX式を表示する', async () => {
+    const sheet = useSheetsStore.getState().sheets[0]
+
+    renderWithRouter(<App />, { initialEntries: [`/${sheet.id}/formula`] })
+
+    const formulaInput = screen.getByRole('textbox')
+    const formulaDisplay = await screen.findByTestId('formula-display')
+    const resultRegion = screen.getByRole('region')
+
+    expect(formulaDisplay).toHaveTextContent('= atan(2*[var1]/[var2])')
+    expect(
+      formulaInput.compareDocumentPosition(formulaDisplay) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy()
+    expect(
+      formulaDisplay.compareDocumentPosition(resultRegion) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy()
+
+    await waitFor(() => {
+      expect(mockRequestPersistentStorage).toHaveBeenCalled()
+    })
+  })
+})


### PR DESCRIPTION
### Motivation
- FormulaタブのUIがOverviewタブと同様に入力式のLaTeX表記を表示しておらず、Formula入力とResult表示の間に同じ表現を挿入する必要があったため。
- ユーザーがFormula欄を確定したタイミングで、Resultと同時にLaTeX表記が更新されるようにしたいという要望に対応するため。

### Description
- `src/pages/FormulaTab.tsx`に`ExpressionRenderer`をインポートして、`FormulaInput`と`ResultDisplay`の間に条件付きでLaTeX表示領域（`data-testid="formula-display"`）を追加した。
- LaTeX表示は`sheet.formulaData.inputExpr`が存在する場合のみ描画するようにしてOverviewタブと同等の表示条件にした。
- `tests/unit/components/App.test.tsx`にFormulaタブでFormula入力欄→LaTeX表示→Result表示の順で配置され、Overviewと同等の式が表示されることを確認するユニットテストを追加した。

### Testing
- 単体テスト（対象ファイル）として `npm run test:unit -- tests/unit/components/App.test.tsx` を実行し、該当テストは成功した（テストはパス）。
- 全ユニットテストを `npm run test:unit` で実行し、すべてのユニットテストが成功した（391 tests passed）。
- E2Eテストを `npm run test:e2e`（Playwright）で実行し、すべてのE2Eケースが成功した（48 passed）。
- さらに `npm run format` / `npm run lint` / `npm run check` / `npm run build` を実行してフォーマット・lint・型チェック・ビルドが問題ないことを確認した。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a390034bdc083319bf36547292901fa)